### PR TITLE
;264R;38R

### DIFF
--- a/class/class-sct-create-content.php
+++ b/class/class-sct-create-content.php
@@ -178,7 +178,7 @@ class Sct_Create_Content extends Sct_Base {
 		$site_url       = get_bloginfo( 'url' );
 		$article_title  = get_the_title( $comment->comment_post_ID );
 		$article_url    = get_permalink( $comment->comment_post_ID );
-		$comment_status = $this->get_comment_approved_message( $tool, $comment );
+		$comment_status = $this->make_comment_approved_message( $tool, $comment );
 
 		if ( 'slack' === $tool ) {
 			$header_emoji     = ':mailbox_with_mail:';

--- a/class/class-sct-create-content.php
+++ b/class/class-sct-create-content.php
@@ -509,7 +509,7 @@ class Sct_Create_Content extends Sct_Base {
 	 * @param string $tool_name Tool name.
 	 * @param object $comment   Comment data.
 	 */
-	private function get_comment_approved_message( string $tool_name, object $comment ): string {
+	private function make_comment_approved_message( string $tool_name, object $comment ): string {
 		$comment_status = '';
 		$approved_url   = admin_url() . 'comment.php?action=approve&c=' . $comment->comment_ID;
 		$unapproved     = $this->get_send_text( 'comment', 'unapproved' );

--- a/tests/SctCreateContentTest.php
+++ b/tests/SctCreateContentTest.php
@@ -150,6 +150,8 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 	 * TEST: make_comment_approved_message
 	 */
 	public function make_comment_approved_message_parameters() {
+		require_once './tests/lib/wordpress-functions.php';
+
 		$comment                   = new stdClass();
 		$comment->comment_ID       = '123';
 		$comment->comment_approved = '1';
@@ -162,7 +164,7 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 		$comment_spam->comment_ID       = '123';
 		$comment_spam->comment_approved = 'spam';
 
-		$admin_url    = 'https://expamle.com/';
+		$admin_url    = admin_url();
 		$approved_url = $admin_url . 'comment.php?action=approve&c=';
 		$unapproved   = 'Unapproved';
 		$click        = 'Click here to approve';

--- a/tests/SctCreateContentTest.php
+++ b/tests/SctCreateContentTest.php
@@ -165,27 +165,27 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 		$admin_url = 'https://expamle.com/';
 
 		return [
-			'Comment status is Approved'                => [
+			'Comment status is Approved'                 => [
 				'slack',
 				$comment,
 				'Approved',
 			],
-			'Comment status is unapproved with slack'   => [
+			'Comment status is unapproved with slack'    => [
 				'slack',
 				$comment_pending,
 				'Unapproved<<' . $admin_url . 'comment.php?action=approve&c=' . $comment_pending->comment_ID . '|Click here to approve>>',
 			],
-			'Comment status is unapproved with discord' => [
+			'Comment status is unapproved with discord'  => [
 				'discord',
 				$comment_pending,
 				'Unapproved >> Click here to approve( ' . $admin_url . 'comment.php?action=approve&c=' . $comment_pending->comment_ID . ' )',
 			],
-			[
+			'Comment status is unapproved with chatwork' => [
 				'chatwork',
 				$comment_pending,
 				'Unapproved' . "\n" . 'Click here to approve ' . $admin_url . 'comment.php?action=approve&c=' . $comment_pending->comment_ID,
 			],
-			'Comment status is spam'                    => [
+			'Comment status is spam'                     => [
 				'spam',
 				$comment_spam,
 				'Spam',

--- a/tests/SctCreateContentTest.php
+++ b/tests/SctCreateContentTest.php
@@ -165,17 +165,17 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 		$admin_url = 'https://expamle.com/';
 
 		return [
-			'Comment status is Approved'              => [
+			'Comment status is Approved'                => [
 				'slack',
 				$comment,
 				'Approved',
 			],
-			'Comment status is unapproved with slack' => [
+			'Comment status is unapproved with slack'   => [
 				'slack',
 				$comment_pending,
 				'Unapproved<<' . $admin_url . 'comment.php?action=approve&c=' . $comment_pending->comment_ID . '|Click here to approve>>',
 			],
-			[
+			'Comment status is unapproved with discord' => [
 				'discord',
 				$comment_pending,
 				'Unapproved >> Click here to approve( ' . $admin_url . 'comment.php?action=approve&c=' . $comment_pending->comment_ID . ' )',
@@ -185,7 +185,7 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 				$comment_pending,
 				'Unapproved' . "\n" . 'Click here to approve ' . $admin_url . 'comment.php?action=approve&c=' . $comment_pending->comment_ID,
 			],
-			'Comment status is spam'                  => [
+			'Comment status is spam'                    => [
 				'spam',
 				$comment_spam,
 				'Spam',

--- a/tests/SctCreateContentTest.php
+++ b/tests/SctCreateContentTest.php
@@ -162,7 +162,8 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 		$comment_spam->comment_ID       = '123';
 		$comment_spam->comment_approved = 'spam';
 
-		$admin_url = 'https://expamle.com/';
+		$admin_url    = 'https://expamle.com/';
+		$approved_url = $admin_url . 'comment.php?action=approve&c=';
 
 		return [
 			'Comment status is Approved'                 => [
@@ -173,17 +174,17 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 			'Comment status is unapproved with slack'    => [
 				'slack',
 				$comment_pending,
-				'Unapproved<<' . $admin_url . 'comment.php?action=approve&c=' . $comment_pending->comment_ID . '|Click here to approve>>',
+				'Unapproved<<' . $approved_url . $comment_pending->comment_ID . '|Click here to approve>>',
 			],
 			'Comment status is unapproved with discord'  => [
 				'discord',
 				$comment_pending,
-				'Unapproved >> Click here to approve( ' . $admin_url . 'comment.php?action=approve&c=' . $comment_pending->comment_ID . ' )',
+				'Unapproved >> Click here to approve( ' . $approved_url . $comment_pending->comment_ID . ' )',
 			],
 			'Comment status is unapproved with chatwork' => [
 				'chatwork',
 				$comment_pending,
-				'Unapproved' . "\n" . 'Click here to approve ' . $admin_url . 'comment.php?action=approve&c=' . $comment_pending->comment_ID,
+				'Unapproved' . "\n" . 'Click here to approve ' . $approved_url . $comment_pending->comment_ID,
 			],
 			'Comment status is spam'                     => [
 				'spam',

--- a/tests/SctCreateContentTest.php
+++ b/tests/SctCreateContentTest.php
@@ -165,12 +165,12 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 		$admin_url = 'https://expamle.com/';
 
 		return [
-			'Comment status is Approved' => [
+			'Comment status is Approved'              => [
 				'slack',
 				$comment,
 				'Approved',
 			],
-			[
+			'Comment status is unapproved with slack' => [
 				'slack',
 				$comment_pending,
 				'Unapproved<<' . $admin_url . 'comment.php?action=approve&c=' . $comment_pending->comment_ID . '|Click here to approve>>',
@@ -185,7 +185,7 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 				$comment_pending,
 				'Unapproved' . "\n" . 'Click here to approve ' . $admin_url . 'comment.php?action=approve&c=' . $comment_pending->comment_ID,
 			],
-			'Comment status is spam'     => [
+			'Comment status is spam'                  => [
 				'spam',
 				$comment_spam,
 				'Spam',

--- a/tests/SctCreateContentTest.php
+++ b/tests/SctCreateContentTest.php
@@ -165,7 +165,7 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 		$admin_url = 'https://expamle.com/';
 
 		return [
-			[
+			'Comment status is Approved' => [
 				'slack',
 				$comment,
 				'Approved',

--- a/tests/SctCreateContentTest.php
+++ b/tests/SctCreateContentTest.php
@@ -154,11 +154,20 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 		$comment->comment_ID       = '123';
 		$comment->comment_approved = '1';
 
+		$comment_spam                   = new stdClass();
+		$comment_spam->comment_ID       = '123';
+		$comment_spam->comment_approved = 'spam';
+
 		return [
 			[
 				'slack',
 				$comment,
 				'Approved',
+			],
+			[
+				'spam',
+				$comment_spam,
+				'Spam',
 			],
 		];
 	}

--- a/tests/SctCreateContentTest.php
+++ b/tests/SctCreateContentTest.php
@@ -164,6 +164,7 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 
 		$admin_url    = 'https://expamle.com/';
 		$approved_url = $admin_url . 'comment.php?action=approve&c=';
+		$unapproved   = 'Unapproved';
 
 		return [
 			'Comment status is Approved'                 => [
@@ -174,17 +175,17 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 			'Comment status is unapproved with slack'    => [
 				'slack',
 				$comment_pending,
-				'Unapproved<<' . $approved_url . $comment_pending->comment_ID . '|Click here to approve>>',
+				$unapproved . '<<' . $approved_url . $comment_pending->comment_ID . '|Click here to approve>>',
 			],
 			'Comment status is unapproved with discord'  => [
 				'discord',
 				$comment_pending,
-				'Unapproved >> Click here to approve( ' . $approved_url . $comment_pending->comment_ID . ' )',
+				$unapproved . ' >> Click here to approve( ' . $approved_url . $comment_pending->comment_ID . ' )',
 			],
 			'Comment status is unapproved with chatwork' => [
 				'chatwork',
 				$comment_pending,
-				'Unapproved' . "\n" . 'Click here to approve ' . $approved_url . $comment_pending->comment_ID,
+				$unapproved . "\n" . 'Click here to approve ' . $approved_url . $comment_pending->comment_ID,
 			],
 			'Comment status is spam'                     => [
 				'spam',

--- a/tests/SctCreateContentTest.php
+++ b/tests/SctCreateContentTest.php
@@ -101,9 +101,18 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * TEST: make_comment_approved_message()
+	 *
+	 * @dataProvider make_comment_approved_message_parameters
+	 *
+	 * @param string $tool_name Chat tool name.
+	 * @param object $comment WordPress comment date.
+	 * @param string $expected Expected value.
 	 */
-	public function test_make_comment_approved_message() {
-		$this->markTestIncomplete( 'This test is incomplete.' );
+	public function test_make_comment_approved_message( string $tool_name, object $comment, string $expected ) {
+		$method = new ReflectionMethod( $this->instance, 'make_comment_approved_message' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $expected, $method->invoke( $this->instance, $tool_name, $comment ) );
 	}
 
 	/**

--- a/tests/SctCreateContentTest.php
+++ b/tests/SctCreateContentTest.php
@@ -154,15 +154,36 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 		$comment->comment_ID       = '123';
 		$comment->comment_approved = '1';
 
+		$comment_pending                   = new stdClass();
+		$comment_pending->comment_ID       = '123';
+		$comment_pending->comment_approved = '0';
+
 		$comment_spam                   = new stdClass();
 		$comment_spam->comment_ID       = '123';
 		$comment_spam->comment_approved = 'spam';
+
+		$admin_url = 'https://expamle.com/';
 
 		return [
 			[
 				'slack',
 				$comment,
 				'Approved',
+			],
+			[
+				'slack',
+				$comment_pending,
+				'Unapproved<<' . $admin_url . 'comment.php?action=approve&c=' . $comment_pending->comment_ID . '|Click here to approve>>',
+			],
+			[
+				'discord',
+				$comment_pending,
+				'Unapproved >> Click here to approve( ' . $admin_url . 'comment.php?action=approve&c=' . $comment_pending->comment_ID . ' )',
+			],
+			[
+				'chatwork',
+				$comment_pending,
+				'Unapproved' . "\n" . 'Click here to approve ' . $admin_url . 'comment.php?action=approve&c=' . $comment_pending->comment_ID,
 			],
 			[
 				'spam',

--- a/tests/SctCreateContentTest.php
+++ b/tests/SctCreateContentTest.php
@@ -165,6 +165,7 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 		$admin_url    = 'https://expamle.com/';
 		$approved_url = $admin_url . 'comment.php?action=approve&c=';
 		$unapproved   = 'Unapproved';
+		$click        = 'Click here to approve';
 
 		return [
 			'Comment status is Approved'                 => [
@@ -175,17 +176,17 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 			'Comment status is unapproved with slack'    => [
 				'slack',
 				$comment_pending,
-				$unapproved . '<<' . $approved_url . $comment_pending->comment_ID . '|Click here to approve>>',
+				$unapproved . '<<' . $approved_url . $comment_pending->comment_ID . '|' . $click . '>>',
 			],
 			'Comment status is unapproved with discord'  => [
 				'discord',
 				$comment_pending,
-				$unapproved . ' >> Click here to approve( ' . $approved_url . $comment_pending->comment_ID . ' )',
+				$unapproved . ' >> ' . $click . '( ' . $approved_url . $comment_pending->comment_ID . ' )',
 			],
 			'Comment status is unapproved with chatwork' => [
 				'chatwork',
 				$comment_pending,
-				$unapproved . "\n" . 'Click here to approve ' . $approved_url . $comment_pending->comment_ID,
+				$unapproved . "\n" . $click . ' ' . $approved_url . $comment_pending->comment_ID,
 			],
 			'Comment status is spam'                     => [
 				'spam',

--- a/tests/SctCreateContentTest.php
+++ b/tests/SctCreateContentTest.php
@@ -100,9 +100,9 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 	}
 
 	/**
-	 * TEST: get_comment_approved_message()
+	 * TEST: make_comment_approved_message()
 	 */
-	public function test_get_comment_approved_message() {
+	public function test_make_comment_approved_message() {
 		$this->markTestIncomplete( 'This test is incomplete.' );
 	}
 

--- a/tests/SctCreateContentTest.php
+++ b/tests/SctCreateContentTest.php
@@ -145,4 +145,21 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 
 		$this->assertSame( $context, $method->invoke( $this->instance, $tool_name, ), );
 	}
+
+	/**
+	 * TEST: make_comment_approved_message
+	 */
+	public function make_comment_approved_message_parameters() {
+		$comment                   = new stdClass();
+		$comment->comment_ID       = '123';
+		$comment->comment_approved = '1';
+
+		return [
+			[
+				'slack',
+				$comment,
+				'Approved',
+			],
+		];
+	}
 }

--- a/tests/SctCreateContentTest.php
+++ b/tests/SctCreateContentTest.php
@@ -185,7 +185,7 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 				$comment_pending,
 				'Unapproved' . "\n" . 'Click here to approve ' . $admin_url . 'comment.php?action=approve&c=' . $comment_pending->comment_ID,
 			],
-			[
+			'Comment status is spam'     => [
 				'spam',
 				$comment_spam,
 				'Spam',

--- a/tests/lib/wordpress-functions.php
+++ b/tests/lib/wordpress-functions.php
@@ -15,6 +15,10 @@ function add_action() {
 	return true;
 }
 
+function admin_url(): string {
+	return 'https://expamle.com/';
+}
+
 function do_action() {
 	return true;
 }


### PR DESCRIPTION
- refs #328 fix test_get_send_text -> implement the test
- refs #328 fix test_create_context method -> implement the test
- refs #328 fix refactor create_context method
- refs #328 fix method name -> make_context
- refs #328 fix method name
- refs #328 fix method name -> use make_context
- refs #328 fix method name create -> make
- refs #328 fix method name create -> make
- refs #328 fix method name create -> make
- refs #328 add admin_url method
- refs #328 fix test_make_comment_approved_message method -> implement the test
- refs #328 add make_comment_approved_message_parameters method -> test_make_comment_approved_message dataprovider method
- refs #328 add spam comment test
- refs #328 add test case -> if the comment is unapproved
- refs #328 fix approved test
- refs #328 fix spam test
- refs #328 fix unapproved with slack test
- refs #328 fix unapproved with discord test
- refs #328 fix unapproved with chatwork test
- refs #328 fix use  variable
- refs #328 fix use  variable
- refs #328 fix use  variable
- refs #328 fix make_comment_approved_message_parameters -> use wordpress-functions.php -> admin_url()
