### PR TITLE
328 fix sct create content

### DIFF
--- a/tests/SctCreateContentTest.php
+++ b/tests/SctCreateContentTest.php
@@ -48,9 +48,19 @@ class SctCreateContentTest extends PHPUnit\Framework\TestCase {
 
 	/**
 	 * TEST: get_comment_data()
+	 *
+	 * @testWith [ 1, 1 ]
+	 *           [ 100, 100 ]
+	 *           [ 2800, 2800 ]
+	 *
+	 * @param int $comment_id Comment->comment_ID.
+	 * @param int $expected Expected value.
 	 */
-	public function test_get_comment_data() {
-		$this->markTestIncomplete( 'This test is incomplete.' );
+	public function test_get_comment_data( int $comment_id, int $expected ): void {
+		$method = new ReflectionMethod( $this->instance, 'get_comment_data' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $expected, $method->invoke( $this->instance, $comment_id )->comment_ID, );
 	}
 
 	/**

--- a/tests/lib/wordpress-functions.php
+++ b/tests/lib/wordpress-functions.php
@@ -26,6 +26,27 @@ function get_bloginfo( $show ) {
 	};
 }
 
+function get_comment( $comment ) {
+	$comment_data                       = new stdClass();
+	$comment_data->comment_ID           = $comment;
+	$comment_data->comment_post_ID      = '123';
+	$comment_data->comment_author       = 'test user';
+	$comment_data->comment_author_email = 'test@example.com';
+	$comment_data->comment_author_url   = 'https://example.com';
+	$comment_data->comment_author_IP    = '123.456.789.123';
+	$comment_data->comment_date         = '2023-01-21 00:40:15';
+	$comment_data->comment_date_gmt     = '2023-01-20 15:40:15';
+	$comment_data->comment_content      = 'test comment';
+	$comment_data->comment_karma        = 0;
+	$comment_data->comment_approved     = '1';
+	$comment_data->comment_agent        = '';
+	$comment_data->comment_type         = '';
+	$comment_data->comment_parent       = '';
+	$comment_data->user_id              = 0;
+
+	return $comment_data;
+}
+
 function get_permalink( $id ) {
 	return 'https://www.example.com/my-post';
 }


### PR DESCRIPTION
- refs #328 fix test_get_send_text -> implement the test
- refs #328 fix test_create_context method -> implement the test
- refs #328 fix refactor create_context method
- refs #328 fix method name -> make_context
- refs #328 fix method name
- refs #328 fix method name -> use make_context
- refs #328 fix method name create -> make
- refs #328 fix method name create -> make
- refs #328 fix method name create -> make
- refs #328 add admin_url method
- refs #328 fix test_make_comment_approved_message method -> implement the test
- refs #328 add make_comment_approved_message_parameters method -> test_make_comment_approved_message dataprovider method
- refs #328 add spam comment test
- refs #328 add test case -> if the comment is unapproved
- refs #328 fix approved test
- refs #328 fix spam test
- refs #328 fix unapproved with slack test
- refs #328 fix unapproved with discord test
- refs #328 fix unapproved with chatwork test
- refs #328 fix use  variable
- refs #328 fix use  variable
- refs #328 fix use  variable
- refs #328 fix make_comment_approved_message_parameters -> use wordpress-functions.php -> admin_url()
- refs #328 add get_bloginfo method -> name, url
- refs #328 add get_the_title method
- refs #328 add get_permalink method
- refs #328 fix test_create_comment_message method -> implement the test
- refs #328 add create_comment_message_parameters method
- refs #328 fix method name create -> make
- refs #328 fix method name create -> make
- refs #328 fix method name create -> make
- refs #328 fix method name create -> make
- refs #328 fix method name create -> make
- refs #328 fix dataProvider method name create -<> make
- refs #328 add return type
- refs #328 add return type
- refs #328 add return type
- refs #328 add return type
- refs #328 add return type
- refs #328 add return type
- refs #328 add get_comment wordpress function
- refs #328 fix test_get_comment_data method -> implemente the test
