### PR TITLE
409 fix Sct Check Update return

### DIFF
--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -49,7 +49,7 @@ class Sct_Check_Update extends Sct_Base {
 	/**
 	 * WordPress Core.
 	 */
-	private function check_core(): array {
+	private function check_core(): ?array {
 		$get_core_status = get_option( '_site_transient_update_core' );
 		$return          = [];
 		if ( ! empty( $get_core_status ) && 'upgrade' === $get_core_status->updates[0]->response ) {

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -70,12 +70,12 @@ class Sct_Check_Update extends Sct_Base {
 	 */
 	private function check_themes(): ?array {
 		$get_theme_status = get_option( '_site_transient_update_themes' );
-		$plugin_data      = null;
+		$theme_data       = null;
 		if ( ! empty( $get_theme_status->response ) ) {
 			$update_themes = $get_theme_status->response;
 			foreach ( $update_themes as $key => $value ) {
-				$theme_date                       = wp_get_theme( $key );
-				$plugin_data[ $theme_date->name ] = [
+				$theme_date                      = wp_get_theme( $key );
+				$theme_data[ $theme_date->name ] = [
 					'name'            => $theme_date->name,
 					'attribute'       => 'theme',
 					'path'            => $theme_date->theme_root . '/' . $key,
@@ -96,7 +96,7 @@ class Sct_Check_Update extends Sct_Base {
 		if ( array_key_exists( $theme_name, self::THEME_OPTION_NAME ) ) {
 			$get_update = get_option( self::THEME_OPTION_NAME[ $theme_name ] );
 			if ( version_compare( $current_version, $get_update->update->version, '<' ) ) {
-				$plugin_data[ $theme_name ] = [
+				$theme_data[ $theme_name ] = [
 					'name'            => $theme_name,
 					'attribute'       => 'theme',
 					'current_version' => $current_version,
@@ -105,7 +105,7 @@ class Sct_Check_Update extends Sct_Base {
 			}
 		}
 
-		return $plugin_data;
+		return $theme_data;
 	}
 
 	/**

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -108,19 +108,19 @@ class Sct_Check_Update extends Sct_Base {
 	 */
 	private function check_plugins(): array {
 		$get_plugin_status = get_option( '_site_transient_update_plugins' );
-		$return            = [];
+		$plugin_data       = [];
 		if ( ! empty( $get_plugin_status->response ) ) {
 			$update_plugins = $get_plugin_status->response;
 			foreach ( $update_plugins as $key ) {
-				$path                 = $this->get_plugin_dir( $key->plugin );
-				$plugin_date          = get_file_data(
+				$path                      = $this->get_plugin_dir( $key->plugin );
+				$plugin_date               = get_file_data(
 					$path,
 					[
 						'name'    => 'Plugin Name',
 						'version' => 'Version',
 					]
 				);
-				$return[ $key->slug ] = [
+				$plugin_data[ $key->slug ] = [
 					'name'            => $plugin_date['name'],
 					'attribute'       => 'plugin',
 					'path'            => $path,
@@ -136,7 +136,7 @@ class Sct_Check_Update extends Sct_Base {
 			if ( array_key_exists( $value['Name'], self::PLUGIN_OPTION_NAME ) ) {
 				$get_update = get_option( self::PLUGIN_OPTION_NAME[ $value['Name'] ] );
 				if ( ! empty( $get_update ) && version_compare( $value['Version'], $get_update->update->version, '<' ) ) {
-					$return[ $value['Name'] ] = [
+					$plugin_data[ $value['Name'] ] = [
 						'name'            => $value['Name'],
 						'attribute'       => 'plugin',
 						'current_version' => $value['Version'],
@@ -146,7 +146,7 @@ class Sct_Check_Update extends Sct_Base {
 			}
 		}
 
-		return $return;
+		return $plugin_data;
 	}
 
 	/**

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -42,7 +42,7 @@ class Sct_Check_Update extends Sct_Base {
 
 		if ( ! empty( $updates ) ) {
 			$next = new Sct_Create_Content();
-			$next->controller( 0, 'update', $updates );
+			$next->controller( type: 'update', update_content: $updates );
 		}
 	}
 

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -31,18 +31,18 @@ class Sct_Check_Update extends Sct_Base {
 	 * Call WordPress Core, Themes and Plugin check function.
 	 */
 	public function controller(): void {
-		$check_data = [];
-		$core       = $this->check_core();
-		$themes     = $this->check_themes();
-		$plugins    = $this->check_plugins();
+		$updates = [];
+		$core    = $this->check_core();
+		$themes  = $this->check_themes();
+		$plugins = $this->check_plugins();
 
 		foreach ( [ $core, $themes, $plugins ] as $value ) {
-			$check_data = array_merge( $check_data, $value ?? [] );
+			$updates = array_merge( $updates, $value ?? [] );
 		}
 
-		if ( ! empty( $check_data ) ) {
+		if ( ! empty( $updates ) ) {
 			$next = new Sct_Create_Content();
-			$next->controller( 0, 'update', $check_data );
+			$next->controller( 0, 'update', $updates );
 		}
 	}
 

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -53,12 +53,12 @@ class Sct_Check_Update extends Sct_Base {
 		$get_core_status = get_option( '_site_transient_update_core' );
 		$update_data     = null;
 		if ( ! empty( $get_core_status ) && 'upgrade' === $get_core_status->updates[0]->response ) {
-			$update_core         = $get_core_status->updates[0];
+			$core_infomation     = $get_core_status->updates[0];
 			$update_data['core'] = [
 				'name'            => 'WordPress Core',
 				'attribute'       => 'core',
 				'current_version' => get_bloginfo( 'version' ),
-				'new_version'     => $update_core->version,
+				'new_version'     => $core_infomation->version,
 			];
 		}
 

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -68,7 +68,7 @@ class Sct_Check_Update extends Sct_Base {
 	/**
 	 * Themes.
 	 */
-	private function check_themes(): array {
+	private function check_themes(): ?array {
 		$get_theme_status = get_option( '_site_transient_update_themes' );
 		$return           = null;
 		if ( ! empty( $get_theme_status->response ) ) {

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -51,17 +51,18 @@ class Sct_Check_Update extends Sct_Base {
 	 */
 	private function check_core(): ?array {
 		$get_core_status = get_option( '_site_transient_update_core' );
-		$return          = [];
+		$update_data     = null;
 		if ( ! empty( $get_core_status ) && 'upgrade' === $get_core_status->updates[0]->response ) {
-			$update_core    = $get_core_status->updates[0];
-			$return['core'] = [
+			$update_core         = $get_core_status->updates[0];
+			$update_data['core'] = [
 				'name'            => 'WordPress Core',
 				'attribute'       => 'core',
 				'current_version' => get_bloginfo( 'version' ),
 				'new_version'     => $update_core->version,
 			];
 		}
-		return $return;
+
+		return $update_data;
 	}
 
 	/**

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -53,12 +53,12 @@ class Sct_Check_Update extends Sct_Base {
 		$get_core_status = get_option( '_site_transient_update_core' );
 		$update_data     = null;
 		if ( ! empty( $get_core_status ) && 'upgrade' === $get_core_status->updates[0]->response ) {
-			$core_infomation     = $get_core_status->updates[0];
+			$update_infomation   = $get_core_status->updates[0];
 			$update_data['core'] = [
 				'name'            => 'WordPress Core',
 				'attribute'       => 'core',
 				'current_version' => get_bloginfo( 'version' ),
-				'new_version'     => $core_infomation->version,
+				'new_version'     => $update_infomation->version,
 			];
 		}
 

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -108,7 +108,7 @@ class Sct_Check_Update extends Sct_Base {
 	 */
 	private function check_plugins(): ?array {
 		$get_plugin_status = get_option( '_site_transient_update_plugins' );
-		$plugin_data       = [];
+		$plugin_data       = null;
 		if ( ! empty( $get_plugin_status->response ) ) {
 			$update_plugins = $get_plugin_status->response;
 			foreach ( $update_plugins as $key ) {

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -132,7 +132,7 @@ class Sct_Check_Update extends Sct_Base {
 
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		$current_plugins = get_plugins();
-		foreach ( $current_plugins as $key => $value ) {
+		foreach ( $current_plugins as $value ) {
 			if ( array_key_exists( $value['Name'], self::PLUGIN_OPTION_NAME ) ) {
 				$get_update = get_option( self::PLUGIN_OPTION_NAME[ $value['Name'] ] );
 				if ( ! empty( $get_update ) && version_compare( $value['Version'], $get_update->update->version, '<' ) ) {

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -70,7 +70,7 @@ class Sct_Check_Update extends Sct_Base {
 	 */
 	private function check_themes(): array {
 		$get_theme_status = get_option( '_site_transient_update_themes' );
-		$return           = [];
+		$return           = null;
 		if ( ! empty( $get_theme_status->response ) ) {
 			$update_themes = $get_theme_status->response;
 			foreach ( $update_themes as $key => $value ) {

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -51,11 +51,11 @@ class Sct_Check_Update extends Sct_Base {
 	 */
 	private function check_core(): ?array {
 		$get_core_status = get_option( '_site_transient_update_core' );
-		$update_data     = null;
+		$core_data       = null;
 
 		if ( ! empty( $get_core_status ) && 'upgrade' === $get_core_status->updates[0]->response ) {
-			$update_infomation   = $get_core_status->updates[0];
-			$update_data['core'] = [
+			$update_infomation = $get_core_status->updates[0];
+			$core_data['core'] = [
 				'name'            => 'WordPress Core',
 				'attribute'       => 'core',
 				'current_version' => get_bloginfo( 'version' ),
@@ -63,7 +63,7 @@ class Sct_Check_Update extends Sct_Base {
 			];
 		}
 
-		return $update_data;
+		return $core_data;
 	}
 
 	/**

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -72,6 +72,7 @@ class Sct_Check_Update extends Sct_Base {
 	private function check_themes(): ?array {
 		$get_theme_status = get_option( '_site_transient_update_themes' );
 		$theme_data       = null;
+
 		if ( ! empty( $get_theme_status->response ) ) {
 			$update_themes = $get_theme_status->response;
 			foreach ( $update_themes as $key => $value ) {

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -106,7 +106,7 @@ class Sct_Check_Update extends Sct_Base {
 	/**
 	 * Plugins.
 	 */
-	private function check_plugins(): array {
+	private function check_plugins(): ?array {
 		$get_plugin_status = get_option( '_site_transient_update_plugins' );
 		$plugin_data       = [];
 		if ( ! empty( $get_plugin_status->response ) ) {

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -70,12 +70,12 @@ class Sct_Check_Update extends Sct_Base {
 	 */
 	private function check_themes(): ?array {
 		$get_theme_status = get_option( '_site_transient_update_themes' );
-		$return           = null;
+		$plugin_data      = null;
 		if ( ! empty( $get_theme_status->response ) ) {
 			$update_themes = $get_theme_status->response;
 			foreach ( $update_themes as $key => $value ) {
-				$theme_date                  = wp_get_theme( $key );
-				$return[ $theme_date->name ] = [
+				$theme_date                       = wp_get_theme( $key );
+				$plugin_data[ $theme_date->name ] = [
 					'name'            => $theme_date->name,
 					'attribute'       => 'theme',
 					'path'            => $theme_date->theme_root . '/' . $key,
@@ -96,7 +96,7 @@ class Sct_Check_Update extends Sct_Base {
 		if ( array_key_exists( $theme_name, self::THEME_OPTION_NAME ) ) {
 			$get_update = get_option( self::THEME_OPTION_NAME[ $theme_name ] );
 			if ( version_compare( $current_version, $get_update->update->version, '<' ) ) {
-				$return[ $theme_name ] = [
+				$plugin_data[ $theme_name ] = [
 					'name'            => $theme_name,
 					'attribute'       => 'theme',
 					'current_version' => $current_version,
@@ -105,7 +105,7 @@ class Sct_Check_Update extends Sct_Base {
 			}
 		}
 
-		return $return;
+		return $plugin_data;
 	}
 
 	/**

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -52,6 +52,7 @@ class Sct_Check_Update extends Sct_Base {
 	private function check_core(): ?array {
 		$get_core_status = get_option( '_site_transient_update_core' );
 		$update_data     = null;
+
 		if ( ! empty( $get_core_status ) && 'upgrade' === $get_core_status->updates[0]->response ) {
 			$update_infomation   = $get_core_status->updates[0];
 			$update_data['core'] = [

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -135,6 +135,7 @@ class Sct_Check_Update extends Sct_Base {
 
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		$current_plugins = get_plugins();
+
 		foreach ( $current_plugins as $value ) {
 			if ( array_key_exists( $value['Name'], self::PLUGIN_OPTION_NAME ) ) {
 				$get_update = get_option( self::PLUGIN_OPTION_NAME[ $value['Name'] ] );

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -42,7 +42,7 @@ class Sct_Check_Update extends Sct_Base {
 
 		if ( ! empty( $updates ) ) {
 			$next = new Sct_Create_Content();
-			$next->controller( type: 'update', update_content: $updates );
+			$next->controller( 0, 'update', $updates );
 		}
 	}
 

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -85,13 +85,8 @@ class Sct_Check_Update extends Sct_Base {
 			}
 		}
 
-		if ( is_child_theme() ) {
-			$theme_name      = wp_get_theme()->parent()->Name;
-			$current_version = wp_get_theme()->parent()->Version;
-		} else {
-			$theme_name      = wp_get_theme()->Name;
-			$current_version = wp_get_theme()->Version;
-		}
+		$theme_name      = is_child_theme() ? wp_get_theme()->parent()->name : wp_get_theme()->Name;
+		$current_version = is_child_theme() ? wp_get_theme()->parent()->Version : wp_get_theme()->Version;
 
 		if ( array_key_exists( $theme_name, self::THEME_OPTION_NAME ) ) {
 			$get_update = get_option( self::THEME_OPTION_NAME[ $theme_name ] );

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -36,9 +36,9 @@ class Sct_Check_Update extends Sct_Base {
 		$themes     = $this->check_themes();
 		$plugins    = $this->check_plugins();
 
-		isset( $core ) ? $check_data    = array_merge( $check_data, $core ) : $check_data;
-		isset( $themes ) ? $check_data  = array_merge( $check_data, $themes ) : $check_data;
-		isset( $plugins ) ? $check_data = array_merge( $check_data, $plugins ) : $check_data;
+		foreach ( [ $core, $themes, $plugins ] as $value ) {
+			$check_data = array_merge( $check_data, $value ?? [] );
+		}
 
 		if ( ! empty( $check_data ) ) {
 			$next = new Sct_Create_Content();

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -111,6 +111,7 @@ class Sct_Check_Update extends Sct_Base {
 	private function check_plugins(): ?array {
 		$get_plugin_status = get_option( '_site_transient_update_plugins' );
 		$plugin_data       = null;
+
 		if ( ! empty( $get_plugin_status->response ) ) {
 			$update_plugins = $get_plugin_status->response;
 			foreach ( $update_plugins as $key ) {


### PR DESCRIPTION
- refs #409 fix return type
- refs #409 fix variable name
- refs #409 fix variable name
- refs #409 fix use foreace and null coalescing operator, unused isset
- refs #409 fix variable name
- refs #409 fix return variable default -> null
- refs #409 fix return type
- refs #409 fix variable name
- refs #409 fix variable name
- refs #409 fix if statement -> ternary operator
- refs #409 fix variable name
- refs #409 fix return type
- refs #409 fix return variable default -> null
- refs #409 refs #409 fix unused $key
- refs #409 add blank line
- refs #409 add blank line
- refs #409 add blank line
- refs #409 add blank line
- refs #409 fix variable name
- refs #409 fix use named arguments
- refs #409 fix variable name
- refs #409 fix unused named arguments
