### PR TITLE
530 fix error mail use abstract class

### DIFF
--- a/class/class-sct-base.php
+++ b/class/class-sct-base.php
@@ -231,7 +231,12 @@ class Sct_Base {
 			'discord'  => 'Sct_Discord',
 			'chatwork' => 'Sct_Chatwork',
 		};
-		$class::get_instance()?->$method_name( $data )?->generate_header()?->send_tools( $type, $tool_name );
+
+		$class::get_instance()
+			?->set_notification_type_original_data( $method_name, $data )
+			?->$method_name( $data )
+			?->generate_header()
+			?->send_tools( $type, $tool_name );
 	}
 
 	/**

--- a/class/class-sct-base.php
+++ b/class/class-sct-base.php
@@ -234,7 +234,7 @@ class Sct_Base {
 
 		$class::get_instance()
 			?->set_notification_type_original_data( $method_name, $data )
-			?->$method_name( $data )
+			?->$method_name()
 			?->generate_header()
 			?->send_tools( $type, $tool_name );
 	}

--- a/class/class-sct-chatwork.php
+++ b/class/class-sct-chatwork.php
@@ -73,11 +73,9 @@ class Sct_Chatwork extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Generate update notifications for Chatwork.
-	 *
-	 * @param array $update_content Update data.
 	 */
-	public function generate_update_content( array $update_content ): Sct_Chatwork {
-		$plain_data = $this->generate_plain_update_message( $update_content );
+	public function generate_update_content(): Sct_Chatwork {
+		$plain_data = $this->generate_plain_update_message( $this->original_data );
 
 		$core    = isset( $plain_data->core ) ? rtrim( $plain_data->core ) . '[hr]' : $plain_data->core;
 		$themes  = isset( $plain_data->themes ) ? rtrim( $plain_data->themes ) . '[hr]' : $plain_data->themes;

--- a/class/class-sct-chatwork.php
+++ b/class/class-sct-chatwork.php
@@ -128,14 +128,12 @@ class Sct_Chatwork extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Generate login message for Slack.
-	 *
-	 * @param object $user User data.
 	 */
-	public function generate_login_message( object $user ): Sct_Chatwork {
+	public function generate_login_message(): Sct_Chatwork {
 		$header_message = $this->generate_header_message( header_message: $this->get_send_text( 'login_notify', 'title' ) );
 
-		$user_name       = $user->data->user_login;
-		$user_email      = $user->data->user_email;
+		$user_name       = $this->original_data->data->user_login;
+		$user_email      = $this->original_data->data->user_email;
 		$login_user_name = $this->get_send_text( 'login_notify', 'user_name' ) . ": {$user_name}<$user_email>";
 
 		$now_date   = gmdate( 'Y-m-d H:i:s', strtotime( current_datetime()->format( 'Y-m-d H:i:s' ) ) );

--- a/class/class-sct-chatwork.php
+++ b/class/class-sct-chatwork.php
@@ -94,16 +94,14 @@ class Sct_Chatwork extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Generate developer message for Chatwork.
-	 *
-	 * @param array $developer_message Developer message.
 	 */
-	public function generate_developer_message( array $developer_message ): Sct_Chatwork {
-		if ( isset( $developer_message['title'] ) && isset( $developer_message['message'] ) && array_key_exists( 'url', $developer_message ) ) {
-			$message_title = sprintf( $this->get_send_text( 'dev_notify', 'title' ), esc_html( $developer_message['title'] ), );
+	public function generate_developer_message(): Sct_Chatwork {
+		if ( isset( $this->original_data['title'] ) && isset( $this->original_data['message'] ) && array_key_exists( 'url', $this->original_data ) ) {
+			$message_title = sprintf( $this->get_send_text( 'dev_notify', 'title' ), esc_html( $this->original_data['title'] ), );
 			$content       = '';
 
 			$i = 0;
-			foreach ( $developer_message['message'] as $value ) {
+			foreach ( $this->original_data['message'] as $value ) {
 				if ( $i >= 50 ) {
 					break;
 				}
@@ -112,8 +110,8 @@ class Sct_Chatwork extends Sct_Generate_Content_Abstract {
 			}
 
 			$header_message  = $this->generate_header_message( header_message: $message_title );
-			$website_url     = $developer_message['url']['website'];
-			$update_page_url = $developer_message['url']['update_page'];
+			$website_url     = $this->original_data['url']['website'];
+			$update_page_url = $this->original_data['url']['update_page'];
 
 			$website     = $website_url ? $this->get_send_text( 'dev_notify', 'website' ) . ': ' . $website_url . "\n" : null;
 			$update_page = $update_page_url ? $this->get_send_text( 'dev_notify', 'detail' ) . ': ' . $update_page_url . "\n" : null;
@@ -121,7 +119,7 @@ class Sct_Chatwork extends Sct_Generate_Content_Abstract {
 			$this->content = [
 				'body' =>
 					'[info]' . $header_message . $content . "\n" . $website . $update_page .
-					'[hr]' . $this->get_send_text( 'dev_notify', 'ignore' ) . ': ' . $developer_message['key'] .
+					'[hr]' . $this->get_send_text( 'dev_notify', 'ignore' ) . ': ' . $this->original_data['key'] .
 					$this->generate_context( $this->tool_name ) . '[/info]',
 			];
 		}

--- a/class/class-sct-chatwork.php
+++ b/class/class-sct-chatwork.php
@@ -159,12 +159,10 @@ class Sct_Chatwork extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Generate Rinker exists items message for Chatwork.
-	 *
-	 * @param array $rinker_exists_items Rinker exists items.
 	 */
-	public function generate_rinker_message( array $rinker_exists_items ): Sct_Chatwork {
+	public function generate_rinker_message(): Sct_Chatwork {
 		$header_message = $this->generate_header_message( header_message: $this->get_send_text( 'rinker_notify', 'title' ) );
-		$items          = $this->generate_rinker_content( $rinker_exists_items );
+		$items          = $this->generate_rinker_content( $this->original_data );
 		$after_message  = $this->get_send_text( 'rinker_notify', 'temporary' ) . "\n" . $this->get_send_text( 'rinker_notify', 'resume' );
 
 		$this->content = [

--- a/class/class-sct-chatwork.php
+++ b/class/class-sct-chatwork.php
@@ -48,25 +48,21 @@ class Sct_Chatwork extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Abstract method to create comment data to be sent to chat tools.
-	 *
-	 * @param object $comment Comment data.
 	 */
-	public function generate_comment_content( object $comment, ): Sct_Chatwork {
-		$this->comment = $comment;
-
-		$article_title  = get_the_title( $comment->comment_post_ID );
-		$article_url    = get_permalink( $comment->comment_post_ID );
-		$comment_status = $this->generate_comment_approved_message( $this->tool_name, $comment );
+	public function generate_comment_content(): Sct_Chatwork {
+		$article_title  = get_the_title( $this->original_data->comment_post_ID );
+		$article_url    = get_permalink( $this->original_data->comment_post_ID );
+		$comment_status = $this->generate_comment_approved_message( $this->tool_name, $this->original_data );
 		$header_message = $this->generate_header_message( header_message: $this->get_send_text( 'comment', 'title' ) );
 
 		$this->content = [
 			'body' =>
 				'[info]' . $header_message .
 				$this->get_send_text( 'comment', 'article' ) . ': ' . $article_title . ' - ' . $article_url . "\n" .
-				$this->get_send_text( 'comment', 'commenter' ) . ': ' . $comment->comment_author . '<' . $comment->comment_author_email . ">\n" .
-				$this->get_send_text( 'constant', 'date' ) . ': ' . $comment->comment_date . "\n" .
-				$this->get_send_text( 'comment', 'comment' ) . ': ' . "\n" . $comment->comment_content . "\n\n" .
-				$this->get_send_text( 'comment', 'url' ) . ': ' . $article_url . '#comment-' . $comment->comment_ID . "\n" .
+				$this->get_send_text( 'comment', 'commenter' ) . ': ' . $this->original_data->comment_author . '<' . $this->original_data->comment_author_email . ">\n" .
+				$this->get_send_text( 'constant', 'date' ) . ': ' . $this->original_data->comment_date . "\n" .
+				$this->get_send_text( 'comment', 'comment' ) . ': ' . "\n" . $this->original_data->comment_content . "\n\n" .
+				$this->get_send_text( 'comment', 'url' ) . ': ' . $article_url . '#comment-' . $this->original_data->comment_ID . "\n" .
 				'[hr]' .
 				$this->get_send_text( 'comment', 'status' ) . ': ' . $comment_status .
 				$this->generate_context( $this->tool_name ) . '[/info]',

--- a/class/class-sct-developer-notify.php
+++ b/class/class-sct-developer-notify.php
@@ -41,12 +41,7 @@ class Sct_Developer_Notify extends Sct_Base {
 						$api_column = 'chatwork' === $tool ? 'api_token' : 'webhook_url';
 
 						if ( $sct_options[ $tool ]['use'] && $sct_options[ $tool ]['send_update'] ) {
-							$instance = match ( $tool ) {
-								'slack'    => Sct_Slack::get_instance(),
-								'discord'  => Sct_Discord::get_instance(),
-								'chatwork' => Sct_Chatwork::get_instance(),
-							};
-							$instance?->generate_developer_message( $developer_message )?->generate_header()?->send_tools( 'update', $tool );
+							$this->call_chat_tool_class( $tool, 'generate_developer_message', 'dev_notify', $developer_message );
 						} elseif ( $sct_options[ $tool ]['use'] && empty( $sct_options[ $tool ][ $api_column ] ) ) {
 							$this->logger( 1001, $tool, '1' );
 						} elseif ( 'chatwork' === $tools && ( $sct_options[ $tool ]['use'] && empty( $sct_options[ $tool ]['room_id'] ) ) ) {

--- a/class/class-sct-discord.php
+++ b/class/class-sct-discord.php
@@ -170,14 +170,12 @@ class Sct_Discord extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Generate Rinker exists items message for Discord.
-	 *
-	 * @param array $rinker_exists_items Rinker exists items.
 	 */
-	public function generate_rinker_message( array $rinker_exists_items ): Sct_Discord {
+	public function generate_rinker_message(): Sct_Discord {
 		$header_emoji   = ':package:';
 		$header_message = $this->generate_header_message( $header_emoji, $this->get_send_text( 'rinker_notify', 'title' ) );
 
-		$items = $this->generate_rinker_content( $rinker_exists_items );
+		$items = $this->generate_rinker_content( $this->original_data );
 
 		$after_message = $this->get_send_text( 'rinker_notify', 'temporary' ) . "\n" . $this->get_send_text( 'rinker_notify', 'resume' );
 

--- a/class/class-sct-discord.php
+++ b/class/class-sct-discord.php
@@ -74,11 +74,9 @@ class Sct_Discord extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Generate update notifications for Discord.
-	 *
-	 * @param array $update_content Update data.
 	 */
-	public function generate_update_content( array $update_content ): Sct_Discord {
-		$plain_data = $this->generate_plain_update_message( $update_content );
+	public function generate_update_content(): Sct_Discord {
+		$plain_data = $this->generate_plain_update_message( $this->original_data );
 
 		$header_emoji    = ':zap:';
 		$header_message  = $this->generate_header_message( $header_emoji, $this->get_send_text( 'update', 'title' ) );

--- a/class/class-sct-discord.php
+++ b/class/class-sct-discord.php
@@ -107,16 +107,14 @@ class Sct_Discord extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Generate developer message for Discord.
-	 *
-	 * @param array $developer_message Developer message.
 	 */
-	public function generate_developer_message( array $developer_message ): Sct_Discord {
-		if ( isset( $developer_message['title'] ) && isset( $developer_message['message'] ) && array_key_exists( 'url', $developer_message ) ) {
-			$message_title = sprintf( $this->get_send_text( 'dev_notify', 'title' ), esc_html( $developer_message['title'] ), );
+	public function generate_developer_message(): Sct_Discord {
+		if ( isset( $this->original_data['title'] ) && isset( $this->original_data['message'] ) && array_key_exists( 'url', $this->original_data ) ) {
+			$message_title = sprintf( $this->get_send_text( 'dev_notify', 'title' ), esc_html( $this->original_data['title'] ), );
 			$content       = '';
 
 			$i = 0;
-			foreach ( $developer_message['message'] as $value ) {
+			foreach ( $this->original_data['message'] as $value ) {
 				if ( $i >= 50 ) {
 					break;
 				}
@@ -126,14 +124,14 @@ class Sct_Discord extends Sct_Generate_Content_Abstract {
 
 			$header_emoji    = ':tada:';
 			$header_message  = $this->generate_header_message( $header_emoji, $message_title );
-			$website_url     = $developer_message['url']['website'];
-			$update_page_url = $developer_message['url']['update_page'];
+			$website_url     = $this->original_data['url']['website'];
+			$update_page_url = $this->original_data['url']['update_page'];
 
 			$title         = $header_message . "\n\n";
 			$main_content  = $content . "\n";
 			$website       = $website_url ? $this->get_send_text( 'dev_notify', 'website' ) . ': <' . $website_url . ">\n" : null;
 			$update_page   = $update_page_url ? $this->get_send_text( 'dev_notify', 'detail' ) . ': <' . $update_page_url . ">\n" : null;
-			$ignore        = "\n" . $this->get_send_text( 'dev_notify', 'ignore' ) . ': ' . $developer_message['key'] . "\n";
+			$ignore        = "\n" . $this->get_send_text( 'dev_notify', 'ignore' ) . ': ' . $this->original_data['key'] . "\n";
 			$this->content = $title . $main_content . $website . $update_page . $ignore . "\n" . $this->generate_context( $this->tool_name );
 		}
 

--- a/class/class-sct-discord.php
+++ b/class/class-sct-discord.php
@@ -48,15 +48,13 @@ class Sct_Discord extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Abstract method to create comment data to be sent to chat tools.
-	 *
-	 * @param object $comment Comment data.
 	 */
-	public function generate_comment_content( object $comment, ): Sct_Discord {
-		$this->comment = $comment;
+	public function generate_comment_content(): Sct_Discord {
+		$this->comment = $this->original_data;
 
-		$article_title  = get_the_title( $comment->comment_post_ID );
-		$article_url    = get_permalink( $comment->comment_post_ID );
-		$comment_status = $this->generate_comment_approved_message( $this->tool_name, $comment );
+		$article_title  = get_the_title( $this->original_data->comment_post_ID );
+		$article_url    = get_permalink( $this->original_data->comment_post_ID );
+		$comment_status = $this->generate_comment_approved_message( $this->tool_name, $this->original_data );
 
 		$header_emoji   = ':mailbox_with_mail:';
 		$header_message = $this->generate_header_message( $header_emoji, $this->get_send_text( 'comment', 'title' ) );
@@ -64,10 +62,10 @@ class Sct_Discord extends Sct_Generate_Content_Abstract {
 		$this->content =
 			$header_message . "\n\n" .
 			'**' . $this->get_send_text( 'comment', 'article' ) . '**: ' . $article_title . ' - <' . $article_url . '>' . "\n" .
-			'**' . $this->get_send_text( 'comment', 'commenter' ) . '**: ' . $comment->comment_author . '<' . $comment->comment_author_email . ">\n" .
-			'**' . $this->get_send_text( 'constant', 'date' ) . '**: ' . $comment->comment_date . "\n" .
-			'**' . $this->get_send_text( 'comment', 'comment' ) . '**: ' . "\n" . $comment->comment_content . "\n\n" .
-			'**' . $this->get_send_text( 'comment', 'url' ) . '**: <' . $article_url . '#comment-' . $comment->comment_ID . '>' . "\n\n" .
+			'**' . $this->get_send_text( 'comment', 'commenter' ) . '**: ' . $this->original_data->comment_author . '<' . $this->original_data->comment_author_email . ">\n" .
+			'**' . $this->get_send_text( 'constant', 'date' ) . '**: ' . $this->original_data->comment_date . "\n" .
+			'**' . $this->get_send_text( 'comment', 'comment' ) . '**: ' . "\n" . $this->original_data->comment_content . "\n\n" .
+			'**' . $this->get_send_text( 'comment', 'url' ) . '**: <' . $article_url . '#comment-' . $this->original_data->comment_ID . '>' . "\n\n" .
 			'**' . $this->get_send_text( 'comment', 'status' ) . '**: ' . $comment_status . "\n\n" .
 			$this->generate_context( $this->tool_name );
 

--- a/class/class-sct-discord.php
+++ b/class/class-sct-discord.php
@@ -140,15 +140,13 @@ class Sct_Discord extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Generate login message for Slack.
-	 *
-	 * @param object $user User data.
 	 */
-	public function generate_login_message( object $user ): Sct_Discord {
+	public function generate_login_message(): Sct_Discord {
 		$header_emoji   = ':unlock:';
 		$header_message = $this->generate_header_message( $header_emoji, $this->get_send_text( 'login_notify', 'title' ) );
 
-		$user_name       = $user->data->user_login;
-		$user_email      = $user->data->user_email;
+		$user_name       = $this->original_data->data->user_login;
+		$user_email      = $this->original_data->data->user_email;
 		$login_user_name = '***' . $this->get_send_text( 'login_notify', 'user_name' ) . "***: {$user_name}<$user_email>";
 
 		$now_date   = gmdate( 'Y-m-d H:i:s', strtotime( current_datetime()->format( 'Y-m-d H:i:s' ) ) );

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -105,10 +105,8 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Generate update notify for Error Mail.
-	 *
-	 * @param array $update_content Update data.
 	 */
-	public function generate_update_content( array $update_content ): Sct_Error_Mail {
+	public function generate_update_content(): Sct_Error_Mail {
 		return $this;
 	}
 

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -55,14 +55,16 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	}
 
 	/**
-	 * A method to set the error code and tool name.
+	 * Method to set properties necessary for error mail generation.
 	 *
-	 * @param int    $error_code Error code.
-	 * @param string $tool_name Tool name.
+	 * @param int          $error_code    Error code.
+	 * @param string       $tool_name     Tool name.
+	 * @param object|array $original_data Original data.
 	 */
-	public function set_error_code_tool_name( int $error_code, string $tool_name ): Sct_Error_Mail {
-		$this->error_code = $error_code;
-		$this->tool_name  = $tool_name;
+	public function set_error_mail_properties( int $error_code, string $tool_name, object | array $original_data ): Sct_Error_Mail {
+		$this->error_code    = $error_code;
+		$this->tool_name     = $tool_name;
+		$this->original_data = $original_data;
 
 		return $this;
 	}
@@ -76,24 +78,22 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Generate comment notify for Error Mail.
-	 *
-	 * @param object $comment Comment data.
 	 */
-	public function generate_comment_content( object $comment, ): Sct_Error_Mail {
+	public function generate_comment_content(): Sct_Error_Mail {
 		$this->mail_title = esc_html__( 'You have received a new comment', 'send-chat-tools' );
 
-		$article_title  = get_the_title( $comment->comment_post_ID );
-		$article_url    = get_permalink( $comment->comment_post_ID );
-		$comment_status = $this->generate_comment_approved_message( $this->tool_name, $comment );
+		$article_title  = get_the_title( $this->original_data->comment_post_ID );
+		$article_url    = get_permalink( $this->original_data->comment_post_ID );
+		$comment_status = $this->generate_comment_approved_message( $this->tool_name, $this->original_data );
 		$header_message = $this->site_name . '(' . $this->site_url . ') ' . $this->get_send_text( 'comment', 'title' );
 
 		$this->content =
 			$header_message . "\n\n" .
 			$this->get_send_text( 'comment', 'article' ) . ': ' . $article_title . ' - ' . $article_url . "\n" .
-			$this->get_send_text( 'comment', 'commenter' ) . ': ' . $comment->comment_author . '<' . $comment->comment_author_email . ">\n" .
-			$this->get_send_text( 'constant', 'date' ) . ': ' . $comment->comment_date . "\n" .
-			$this->get_send_text( 'comment', 'comment' ) . ': ' . "\n" . $comment->comment_content . "\n\n" .
-			$this->get_send_text( 'comment', 'url' ) . ': ' . $article_url . '#comment-' . $comment->comment_ID . "\n" .
+			$this->get_send_text( 'comment', 'commenter' ) . ': ' . $this->original_data->comment_author . '<' . $this->original_data->comment_author_email . ">\n" .
+			$this->get_send_text( 'constant', 'date' ) . ': ' . $this->original_data->comment_date . "\n" .
+			$this->get_send_text( 'comment', 'comment' ) . ': ' . "\n" . $this->original_data->comment_content . "\n\n" .
+			$this->get_send_text( 'comment', 'url' ) . ': ' . $article_url . '#comment-' . $this->original_data->comment_ID . "\n" .
 			$this->get_send_text( 'comment', 'status' ) . ': ' . $comment_status . "\n\n" .
 			esc_html__( 'This message was sent by Send Chat Tools.', 'send-chat-tools' ) . "\n" .
 			esc_html__( 'Possible that the message was not sent to the chat tool correctly.', 'send-chat-tools' ) . "\n\n" .

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -164,6 +164,31 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 * Generate login notify for Error Mail.
 	 */
 	public function generate_login_message(): Sct_Error_Mail {
+		$this->mail_title = $this->get_send_text( 'login_notify', 'title' );
+
+		$user_name       = $this->original_data->data->user_login;
+		$user_email      = $this->original_data->data->user_email;
+		$login_user_name = $this->get_send_text( 'login_notify', 'user_name' ) . ": {$user_name}<$user_email>";
+
+		$now_date   = gmdate( 'Y-m-d H:i:s', strtotime( current_datetime()->format( 'Y-m-d H:i:s' ) ) );
+		$login_date = $this->get_send_text( 'constant', 'date' ) . ": {$now_date}";
+
+		$os_browser = getenv( 'HTTP_USER_AGENT' );
+		$login_env  = $this->get_send_text( 'login_notify', 'login_env' ) . ": {$os_browser}";
+
+		$ip_address       = getenv( 'REMOTE_ADDR' );
+		$login_ip_address = $this->get_send_text( 'login_notify', 'ip_address' ) . ": {$ip_address}";
+
+		$this->content =
+			$this->site_name . '(' . $this->site_url . ') ' . $this->mail_title . "\n\n" .
+			$login_user_name . "\n" . $login_date . "\n" . $login_env . "\n" . $login_ip_address . "\n\n" .
+			$this->get_send_text( 'login_notify', 'unauthorized_login' ) . "\n" .
+			$this->get_send_text( 'login_notify', 'disconnect' ) . "\n" .
+			$this->site_url . '/wp-admin/profile.php' . "\n\n" .
+			$this->generate_context( 'error_mail' ) . "\n" .
+			esc_html__( 'Tool name:', 'send-chat-tools' ) . ucfirst( $this->tool_name ) . "\n" .
+			esc_html__( 'Error code:', 'send-chat-tools' ) . $this->error_code;
+
 		return $this;
 	}
 

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -59,6 +59,35 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 * @param object $comment Comment data.
 	 */
 	public function generate_comment_content( object $comment, ): Sct_Error_Mail {
+		$comment          = get_comment( $this->comment_id );
+		$comment_approved = $comment->comment_approved;
+		$article_title    = get_the_title( $comment->comment_post_ID );
+		$article_url      = get_permalink( $comment->comment_post_ID );
+		$approved_url     = admin_url() . 'comment.php?action=approve&c=' . $comment->comment_ID;
+
+		$comment_status = match ( $comment_approved ) {
+			'1'    => $comment_status = esc_html__( 'Approved', 'send-chat-tools' ),
+			'0'    => esc_html__( 'Unapproved', 'send-chat-tools' ) . '<<' . $approved_url . '|' . esc_html__( 'Click here to approve', 'send-chat-tools' ) . '>>',
+			'spam' => esc_html__( 'Spam', 'send-chat-tools' ),
+		};
+
+		$mail_to      = get_option( 'admin_email' );
+		$mail_title   = esc_html__( 'You have received a new comment', 'send-chat-tools' );
+		$mail_message =
+			$this->site_name . '( ' . $this->site_url . ' )' . esc_html__( 'new comment has been posted.', 'send-chat-tools' ) . "\n\n" .
+			esc_html__( 'Commented article:', 'send-chat-tools' ) . $article_title . ' - ' . $article_url . "\n" .
+			esc_html__( 'Author:', 'send-chat-tools' ) . $comment->comment_author . '<' . $comment->comment_author_email . ">\n" .
+			esc_html__( 'Date and time:', 'send-chat-tools' ) . $comment->comment_date . "\n" .
+			esc_html__( 'Text:', 'send-chat-tools' ) . "\n" . $comment->comment_content . "\n\n" .
+			esc_html__( 'Comment URL:', 'send-chat-tools' ) . $article_url . '#comment-' . $comment->comment_ID . "\n\n" .
+			esc_html__( 'Comment Status:', 'send-chat-tools' ) . $comment_status . "\n\n" .
+			esc_html__( 'This message was sent by Send Chat Tools.', 'send-chat-tools' ) . "\n" .
+			esc_html__( 'Possible that the message was not sent to the chat tool correctly.', 'send-chat-tools' ) . "\n\n" .
+			esc_html__( 'Tool name:', 'send-chat-tools' ) . ucfirst( $this->tool_name ) . "\n" .
+			esc_html__( 'Error code:', 'send-chat-tools' ) . $this->error_code;
+
+		$this->content = [ $mail_to, $mail_title, $mail_message ];
+
 		return $this;
 	}
 

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -107,6 +107,19 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 * Generate update notify for Error Mail.
 	 */
 	public function generate_update_content(): Sct_Error_Mail {
+		$this->mail_title = $this->get_send_text( 'update', 'title' );
+
+		$plain_data = $this->generate_plain_update_message( $this->original_data );
+
+		$header_message = $this->site_name . '(' . $this->site_url . ') ' . $this->get_send_text( 'update', 'title' );
+
+		$this->content =
+			$header_message . "\n\n" . $plain_data->core . $plain_data->themes . $plain_data->plugins .
+			$this->get_send_text( 'update', 'update' ) . "\n" . $this->get_send_text( 'update', 'page' ) . ': ' . $plain_data->admin_url . "\n\n" .
+			$this->generate_context( 'error_mail' ) . "\n" .
+			esc_html__( 'Tool name:', 'send-chat-tools' ) . ucfirst( $this->tool_name ) . "\n" .
+			esc_html__( 'Error code:', 'send-chat-tools' ) . $this->error_code;
+
 		return $this;
 	}
 

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -19,16 +19,23 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 class Sct_Error_Mail extends Sct_Base {
 	/**
-	 * Constructor.
+	 * Property to store error code.
 	 *
-	 * @param int    $error_code error code.
-	 * @param string $comment_id comment ID.
-	 * @param string $tool_name  Tool name.
+	 * @var int $error_code.
 	 */
-	public function __construct( private int $error_code, private string $comment_id, private string $tool_name ) {
-		$this->error_code = $error_code;
-		$this->comment_id = $comment_id;
-		$this->tool_name  = $tool_name;
+	private int $error_code;
+
+	/**
+	 * Property to store comment ID.
+	 *
+	 * @var string $comment_id.
+	 */
+	private string $comment_id;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
 	}
 
 	/**

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -26,13 +26,6 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	private int $error_code;
 
 	/**
-	 * Property to store comment ID.
-	 *
-	 * @var string $comment_id.
-	 */
-	private string $comment_id;
-
-	/**
 	 * Property to store mail to.
 	 *
 	 * @var string $mail_to.

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -197,6 +197,19 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 * Generate Rinker notify for Error Mail.
 	 */
 	public function generate_rinker_message(): Sct_Error_Mail {
+		$this->mail_title = $this->get_send_text( 'rinker_notify', 'title' );
+
+		$items = $this->generate_rinker_content( $this->original_data );
+
+		$after_message = $this->get_send_text( 'rinker_notify', 'temporary' ) . "\n" . $this->get_send_text( 'rinker_notify', 'resume' );
+
+		$this->content =
+			$this->site_name . '(' . $this->site_url . ') ' . $this->mail_title . "\n\n" .
+			$items . "\n\n" . $after_message . "\n\n" .
+			$this->generate_context( 'error_mail' ) . "\n" .
+			esc_html__( 'Tool name:', 'send-chat-tools' ) . ucfirst( $this->tool_name ) . "\n" .
+			esc_html__( 'Error code:', 'send-chat-tools' ) . $this->error_code;
+
 		return $this;
 	}
 

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -128,42 +128,6 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	}
 
 	/**
-	 * Generate mail to, title, and message.
-	 */
-	public function generate_contents(): array {
-		$comment          = get_comment( $this->comment_id );
-		$site_name        = get_bloginfo( 'name' );
-		$site_url         = get_bloginfo( 'url' );
-		$comment_approved = $comment->comment_approved;
-		$article_title    = get_the_title( $comment->comment_post_ID );
-		$article_url      = get_permalink( $comment->comment_post_ID );
-		$approved_url     = admin_url() . 'comment.php?action=approve&c=' . $comment->comment_ID;
-
-		$comment_status = match ( $comment_approved ) {
-			'1'    => $comment_status = esc_html__( 'Approved', 'send-chat-tools' ),
-			'0'    => esc_html__( 'Unapproved', 'send-chat-tools' ) . '<<' . $approved_url . '|' . esc_html__( 'Click here to approve', 'send-chat-tools' ) . '>>',
-			'spam' => esc_html__( 'Spam', 'send-chat-tools' ),
-		};
-
-		$mail_to      = get_option( 'admin_email' );
-		$mail_title   = esc_html__( 'You have received a new comment', 'send-chat-tools' );
-		$mail_message =
-			$site_name . '( ' . $site_url . ' )' . esc_html__( 'new comment has been posted.', 'send-chat-tools' ) . "\n\n" .
-			esc_html__( 'Commented article:', 'send-chat-tools' ) . $article_title . ' - ' . $article_url . "\n" .
-			esc_html__( 'Author:', 'send-chat-tools' ) . $comment->comment_author . '<' . $comment->comment_author_email . ">\n" .
-			esc_html__( 'Date and time:', 'send-chat-tools' ) . $comment->comment_date . "\n" .
-			esc_html__( 'Text:', 'send-chat-tools' ) . "\n" . $comment->comment_content . "\n\n" .
-			esc_html__( 'Comment URL:', 'send-chat-tools' ) . $article_url . '#comment-' . $comment->comment_ID . "\n\n" .
-			esc_html__( 'Comment Status:', 'send-chat-tools' ) . $comment_status . "\n\n" .
-			esc_html__( 'This message was sent by Send Chat Tools.', 'send-chat-tools' ) . "\n" .
-			esc_html__( 'Possible that the message was not sent to the chat tool correctly.', 'send-chat-tools' ) . "\n\n" .
-			esc_html__( 'Tool name:', 'send-chat-tools' ) . ucfirst( $this->tool_name ) . "\n" .
-			esc_html__( 'Error code:', 'send-chat-tools' ) . $this->error_code;
-
-		return [ $mail_to, $mail_title, $mail_message ];
-	}
-
-	/**
 	 * Generate WordPress Core, Theme, Plugin update content.
 	 *
 	 * @param object $plain_data The outgoing message is stored.

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -50,6 +50,8 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 * Constructor.
 	 */
 	public function __construct() {
+		parent::__construct();
+		$this->mail_to = get_option( 'admin_email' );
 	}
 
 	/**

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -126,10 +126,8 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Generate Rinker notify for Error Mail.
-	 *
-	 * @param array $rinker_exists_items Rinker exists items.
 	 */
-	public function generate_rinker_message( array $rinker_exists_items ): Sct_Error_Mail {
+	public function generate_rinker_message(): Sct_Error_Mail {
 		return $this;
 	}
 

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -88,6 +88,8 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 * @param object $comment Comment data.
 	 */
 	public function generate_comment_content( object $comment, ): Sct_Error_Mail {
+		$this->mail_title = esc_html__( 'You have received a new comment', 'send-chat-tools' );
+
 		$article_title  = get_the_title( $comment->comment_post_ID );
 		$article_url    = get_permalink( $comment->comment_post_ID );
 		$comment_status = $this->generate_comment_approved_message( $this->tool_name, $comment );

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -119,10 +119,8 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Generate login notify for Error Mail.
-	 *
-	 * @param object $user User object.
 	 */
-	public function generate_login_message( object $user ): Sct_Error_Mail {
+	public function generate_login_message(): Sct_Error_Mail {
 		return $this;
 	}
 

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -112,10 +112,8 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Generate developer notify for Error Mail.
-	 *
-	 * @param array $developer_message Developer message.
 	 */
-	public function generate_developer_message( array $developer_message ): Sct_Error_Mail {
+	public function generate_developer_message(): Sct_Error_Mail {
 		return $this;
 	}
 

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -79,7 +79,6 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 */
 	public function generate_header(): Sct_Error_Mail {
 		return $this;
-
 	}
 
 	/**

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -46,6 +46,19 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	}
 
 	/**
+	 * A method to set the error code and tool name.
+	 *
+	 * @param int    $error_code Error code.
+	 * @param string $tool_name Tool name.
+	 */
+	public function set_error_code_tool_name( int $error_code, string $tool_name ): Sct_Error_Mail {
+		$this->error_code = $error_code;
+		$this->tool_name  = $tool_name;
+
+		return $this;
+	}
+
+	/**
 	 * A method to generate a Error Mail header.
 	 */
 	public function generate_header(): Sct_Error_Mail {
@@ -59,7 +72,7 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 * @param object $comment Comment data.
 	 */
 	public function generate_comment_content( object $comment, ): Sct_Error_Mail {
-		$comment          = get_comment( $this->comment_id );
+		update_option( 'sct_call', 'called' );
 		$comment_approved = $comment->comment_approved;
 		$article_title    = get_the_title( $comment->comment_post_ID );
 		$article_url      = get_permalink( $comment->comment_post_ID );
@@ -155,6 +168,7 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 * @param string $mail_message mail message.
 	 */
 	public function send_mail( string $mail_to, string $mail_title, string $mail_message ): void {
+		update_option( 'sct_error_mail', $mail_to );
 		wp_mail( $mail_to, $mail_title, $mail_message );
 	}
 }

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Send error mail.
  */
-class Sct_Error_Mail extends Sct_Base {
+class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	/**
 	 * Property to store error code.
 	 *
@@ -36,6 +36,66 @@ class Sct_Error_Mail extends Sct_Base {
 	 * Constructor.
 	 */
 	public function __construct() {
+	}
+
+	/**
+	 * Instantiate and return itself.
+	 */
+	public static function get_instance(): Sct_Error_Mail {
+		return new self();
+	}
+
+	/**
+	 * A method to generate a Error Mail header.
+	 */
+	public function generate_header(): Sct_Error_Mail {
+		return $this;
+
+	}
+
+	/**
+	 * Generate comment notify for Error Mail.
+	 *
+	 * @param object $comment Comment data.
+	 */
+	public function generate_comment_content( object $comment, ): Sct_Error_Mail {
+		return $this;
+	}
+
+	/**
+	 * Generate update notify for Error Mail.
+	 *
+	 * @param array $update_content Update data.
+	 */
+	public function generate_update_content( array $update_content ): Sct_Error_Mail {
+		return $this;
+	}
+
+	/**
+	 * Generate developer notify for Error Mail.
+	 *
+	 * @param array $developer_message Developer message.
+	 */
+	public function generate_developer_message( array $developer_message ): Sct_Error_Mail {
+		return $this;
+	}
+
+	/**
+	 * Generate login notify for Error Mail.
+	 *
+	 * @param object $user User object.
+	 */
+	public function generate_login_message( object $user ): Sct_Error_Mail {
+		return $this;
+	}
+
+	/**
+	 * Generate Rinker notify for Error Mail.
+	 *
+	 * @param array $rinker_exists_items Rinker exists items.
+	 */
+	public function generate_rinker_message( array $rinker_exists_items ): Sct_Error_Mail {
+		return $this;
 	}
 
 	/**

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -127,6 +127,36 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 * Generate developer notify for Error Mail.
 	 */
 	public function generate_developer_message(): Sct_Error_Mail {
+		$this->mail_title = sprintf( $this->get_send_text( 'dev_notify', 'title' ), esc_html( $this->original_data['title'] ), );
+
+		$content = '';
+		update_option( 'sct_dev_error', 'called' );
+
+		$i = 0;
+		foreach ( $this->original_data['message'] as $value ) {
+			if ( $i >= 50 ) {
+				break;
+			}
+			$content .= $value . "\n";
+			$i++;
+		}
+
+		$header_message  = $this->site_name . '(' . $this->site_url . ') ' . sprintf( $this->get_send_text( 'dev_notify', 'title' ), esc_html( $this->original_data['title'] ), );
+		$website_url     = $this->original_data['url']['website'];
+		$update_page_url = $this->original_data['url']['update_page'];
+
+		$title        = $header_message . "\n\n";
+		$main_content = $content . "\n";
+		$website      = $website_url ? $this->get_send_text( 'dev_notify', 'website' ) . ': <' . $website_url . ">\n" : null;
+		$update_page  = $update_page_url ? $this->get_send_text( 'dev_notify', 'detail' ) . ': <' . $update_page_url . ">\n" : null;
+		$ignore       = "\n" . $this->get_send_text( 'dev_notify', 'ignore' ) . ': ' . $this->original_data['key'] . "\n";
+
+		$this->content =
+			$title . $main_content . $website . $update_page . $ignore . "\n" .
+			$this->generate_context( 'error_mail' ) . "\n" .
+			esc_html__( 'Tool name:', 'send-chat-tools' ) . ucfirst( $this->tool_name ) . "\n" .
+			esc_html__( 'Error code:', 'send-chat-tools' ) . $this->error_code;
+
 		return $this;
 	}
 

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -65,6 +65,7 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 		$this->error_code    = $error_code;
 		$this->tool_name     = $tool_name;
 		$this->original_data = $original_data;
+		$this->is_error_mail = true;
 
 		return $this;
 	}

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -33,6 +33,20 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	private string $comment_id;
 
 	/**
+	 * Property to store mail to.
+	 *
+	 * @var string $mail_to.
+	 */
+	private string $mail_to;
+
+	/**
+	 * Property to store mail title.
+	 *
+	 * @var string $mail_title.
+	 */
+	private string $mail_title;
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -169,12 +169,8 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Send mail.
-	 *
-	 * @param string $mail_to mail to.
-	 * @param string $mail_title mail title.
-	 * @param string $mail_message mail message.
 	 */
-	public function send_mail( string $mail_to, string $mail_title, string $mail_message ): void {
-		wp_mail( $mail_to, $mail_title, $mail_message );
+	public function send_mail(): void {
+		wp_mail( $this->mail_to, $this->mail_title, $this->content );
 	}
 }

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -72,33 +72,23 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 * @param object $comment Comment data.
 	 */
 	public function generate_comment_content( object $comment, ): Sct_Error_Mail {
-		$comment_approved = $comment->comment_approved;
-		$article_title    = get_the_title( $comment->comment_post_ID );
-		$article_url      = get_permalink( $comment->comment_post_ID );
-		$approved_url     = admin_url() . 'comment.php?action=approve&c=' . $comment->comment_ID;
+		$article_title  = get_the_title( $comment->comment_post_ID );
+		$article_url    = get_permalink( $comment->comment_post_ID );
+		$comment_status = $this->generate_comment_approved_message( $this->tool_name, $comment );
+		$header_message = $this->site_name . '(' . $this->site_url . ') ' . $this->get_send_text( 'comment', 'title' );
 
-		$comment_status = match ( $comment_approved ) {
-			'1'    => $comment_status = esc_html__( 'Approved', 'send-chat-tools' ),
-			'0'    => esc_html__( 'Unapproved', 'send-chat-tools' ) . '<<' . $approved_url . '|' . esc_html__( 'Click here to approve', 'send-chat-tools' ) . '>>',
-			'spam' => esc_html__( 'Spam', 'send-chat-tools' ),
-		};
-
-		$mail_to      = get_option( 'admin_email' );
-		$mail_title   = esc_html__( 'You have received a new comment', 'send-chat-tools' );
-		$mail_message =
-			$this->site_name . '( ' . $this->site_url . ' )' . esc_html__( 'new comment has been posted.', 'send-chat-tools' ) . "\n\n" .
-			esc_html__( 'Commented article:', 'send-chat-tools' ) . $article_title . ' - ' . $article_url . "\n" .
-			esc_html__( 'Author:', 'send-chat-tools' ) . $comment->comment_author . '<' . $comment->comment_author_email . ">\n" .
-			esc_html__( 'Date and time:', 'send-chat-tools' ) . $comment->comment_date . "\n" .
-			esc_html__( 'Text:', 'send-chat-tools' ) . "\n" . $comment->comment_content . "\n\n" .
-			esc_html__( 'Comment URL:', 'send-chat-tools' ) . $article_url . '#comment-' . $comment->comment_ID . "\n\n" .
-			esc_html__( 'Comment Status:', 'send-chat-tools' ) . $comment_status . "\n\n" .
+		$this->content =
+			$header_message . "\n\n" .
+			$this->get_send_text( 'comment', 'article' ) . ': ' . $article_title . ' - ' . $article_url . "\n" .
+			$this->get_send_text( 'comment', 'commenter' ) . ': ' . $comment->comment_author . '<' . $comment->comment_author_email . ">\n" .
+			$this->get_send_text( 'constant', 'date' ) . ': ' . $comment->comment_date . "\n" .
+			$this->get_send_text( 'comment', 'comment' ) . ': ' . "\n" . $comment->comment_content . "\n\n" .
+			$this->get_send_text( 'comment', 'url' ) . ': ' . $article_url . '#comment-' . $comment->comment_ID . "\n" .
+			$this->get_send_text( 'comment', 'status' ) . ': ' . $comment_status . "\n\n" .
 			esc_html__( 'This message was sent by Send Chat Tools.', 'send-chat-tools' ) . "\n" .
 			esc_html__( 'Possible that the message was not sent to the chat tool correctly.', 'send-chat-tools' ) . "\n\n" .
 			esc_html__( 'Tool name:', 'send-chat-tools' ) . ucfirst( $this->tool_name ) . "\n" .
 			esc_html__( 'Error code:', 'send-chat-tools' ) . $this->error_code;
-
-		$this->content = [ $mail_to, $mail_title, $mail_message ];
 
 		return $this;
 	}

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -72,7 +72,6 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 * @param object $comment Comment data.
 	 */
 	public function generate_comment_content( object $comment, ): Sct_Error_Mail {
-		update_option( 'sct_call', 'called' );
 		$comment_approved = $comment->comment_approved;
 		$article_title    = get_the_title( $comment->comment_post_ID );
 		$article_url      = get_permalink( $comment->comment_post_ID );
@@ -168,7 +167,6 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 * @param string $mail_message mail message.
 	 */
 	public function send_mail( string $mail_to, string $mail_title, string $mail_message ): void {
-		update_option( 'sct_error_mail', $mail_to );
 		wp_mail( $mail_to, $mail_title, $mail_message );
 	}
 }

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -214,26 +214,6 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	}
 
 	/**
-	 * Generate WordPress Core, Theme, Plugin update content.
-	 *
-	 * @param object $plain_data The outgoing message is stored.
-	 */
-	public function update_contents( object $plain_data ): array {
-		$mail_to      = get_option( 'admin_email' );
-		$mail_title   = esc_html__( 'WordPress update notification.', 'send-chat-tools' );
-		$mail_message =
-			$plain_data->site_name . '(' . $plain_data->site_url . ')' . $plain_data->update_title . "\n\n" .
-			$plain_data->core . $plain_data->themes . $plain_data->plugins . $plain_data->update_text . "\n" .
-			$plain_data->update_page . $plain_data->admin_url . "\n\n" .
-			esc_html__( 'This message was sent by Send Chat Tools.', 'send-chat-tools' ) . "\n" .
-			esc_html__( 'Possible that the message was not sent to the chat tool correctly.', 'send-chat-tools' ) . "\n\n" .
-			esc_html__( 'Tool name:', 'send-chat-tools' ) . ucfirst( $this->tool_name ) . "\n" .
-			esc_html__( 'Error code:', 'send-chat-tools' ) . $this->error_code;
-
-		return [ $mail_to, $mail_title, $mail_message ];
-	}
-
-	/**
 	 * Send mail.
 	 */
 	public function send_mail(): void {

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -71,47 +71,47 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 	/**
 	 * Abstract method to get an instance.
 	 */
-	abstract public static function get_instance(): Sct_Slack | Sct_Discord | Sct_Chatwork;
+	abstract public static function get_instance(): Sct_Slack | Sct_Discord | Sct_Chatwork | Sct_Error_Mail;
 
 	/**
 	 * Abstract method to generate a chat tool header.
 	 */
-	abstract public function generate_header(): Sct_Slack | Sct_Discord | Sct_Chatwork;
+	abstract public function generate_header(): Sct_Slack | Sct_Discord | Sct_Chatwork | Sct_Error_Mail;
 
 	/**
 	 * Abstract method to generate comment content to be sent to chat tools.
 	 *
 	 * @param object $comment Comment data.
 	 */
-	abstract public function generate_comment_content( object $comment, ): Sct_Slack | Sct_Discord | Sct_Chatwork;
+	abstract public function generate_comment_content( object $comment, ): Sct_Slack | Sct_Discord | Sct_Chatwork | Sct_Error_Mail;
 
 	/**
 	 * Abstract method to generate update content to be sent to chat tools.
 	 *
 	 * @param array $update_content Update data.
 	 */
-	abstract public function generate_update_content( array $update_content ): Sct_Slack | Sct_Discord | Sct_Chatwork;
+	abstract public function generate_update_content( array $update_content ): Sct_Slack | Sct_Discord | Sct_Chatwork | Sct_Error_Mail;
 
 	/**
 	 * Abstract method to generate developer message content to be sent to chat tools.
 	 *
 	 * @param array $developer_message Update data.
 	 */
-	abstract public function generate_developer_message( array $developer_message ): Sct_Slack | Sct_Discord | Sct_Chatwork;
+	abstract public function generate_developer_message( array $developer_message ): Sct_Slack | Sct_Discord | Sct_Chatwork | Sct_Error_Mail;
 
 	/**
 	 * Abstract method to generate login message content to be sent to chat tools.
 	 *
 	 * @param object $user User data.
 	 */
-	abstract public function generate_login_message( object $user ): Sct_Slack | Sct_Discord | Sct_Chatwork;
+	abstract public function generate_login_message( object $user ): Sct_Slack | Sct_Discord | Sct_Chatwork | Sct_Error_Mail;
 
 	/**
 	 * Abstract method to generate Rinker exists items message content to be sent to chat tools.
 	 *
 	 * @param array $rinker_exists_items Rinker exists items.
 	 */
-	abstract public function generate_rinker_message( array $rinker_exists_items ): Sct_Slack | Sct_Discord | Sct_Chatwork;
+	abstract public function generate_rinker_message( array $rinker_exists_items ): Sct_Slack | Sct_Discord | Sct_Chatwork | Sct_Error_Mail;
 
 	/**
 	 * Method to generate headers for each chat tool.

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -61,6 +61,20 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 	protected $site_url;
 
 	/**
+	 * Property that stores the type of notification.
+	 *
+	 * @var string Notification type.
+	 */
+	protected $notification_type;
+
+	/**
+	 * Property that stores the original data before processing.
+	 *
+	 * @var array Original data.
+	 */
+	protected $original_data;
+
+	/**
 	 * Constructor to obtain information necessary for content generation.
 	 */
 	protected function __construct() {

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -109,10 +109,8 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 
 	/**
 	 * Abstract method to generate login message content to be sent to chat tools.
-	 *
-	 * @param object $user User data.
 	 */
-	abstract public function generate_login_message( object $user ): Sct_Slack | Sct_Discord | Sct_Chatwork | Sct_Error_Mail;
+	abstract public function generate_login_message(): Sct_Slack | Sct_Discord | Sct_Chatwork | Sct_Error_Mail;
 
 	/**
 	 * Abstract method to generate Rinker exists items message content to be sent to chat tools.

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -99,10 +99,8 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 
 	/**
 	 * Abstract method to generate update content to be sent to chat tools.
-	 *
-	 * @param array $update_content Update data.
 	 */
-	abstract public function generate_update_content( array $update_content ): Sct_Slack | Sct_Discord | Sct_Chatwork | Sct_Error_Mail;
+	abstract public function generate_update_content(): Sct_Slack | Sct_Discord | Sct_Chatwork | Sct_Error_Mail;
 
 	/**
 	 * Abstract method to generate developer message content to be sent to chat tools.

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -349,13 +349,7 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 
 		if ( 200 !== $status_code && 204 !== $status_code ) {
 			require_once dirname( __FILE__ ) . '/class-sct-error-mail.php';
-			if ( 'update' === $id ) {
-				$send_mail = new Sct_Error_Mail( $status_code, $id, $tool );
-				$send_mail->send_mail( ...$send_mail->update_contents( $options['plain_data'] ) );
-			} else {
-				$send_mail = new Sct_Error_Mail( $status_code, $id, $tool );
-				$send_mail->send_mail( ...$send_mail->generate_contents() );
-			}
+			$this->call_error_mail_class( $status_code, $tool );
 		}
 
 		return $this->logger( $status_code, $tool, $id );

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -104,10 +104,8 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 
 	/**
 	 * Abstract method to generate developer message content to be sent to chat tools.
-	 *
-	 * @param array $developer_message Update data.
 	 */
-	abstract public function generate_developer_message( array $developer_message ): Sct_Slack | Sct_Discord | Sct_Chatwork | Sct_Error_Mail;
+	abstract public function generate_developer_message(): Sct_Slack | Sct_Discord | Sct_Chatwork | Sct_Error_Mail;
 
 	/**
 	 * Abstract method to generate login message content to be sent to chat tools.

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -203,7 +203,7 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 	 * @param array $rinker_exists_items Rinker exists items.
 	 */
 	protected function generate_rinker_content( array $rinker_exists_items ): string {
-		$format = match ( $this->tool_name ) {
+		$format = $this->is_error_mail ? "    ・ %2\$s\n         %1\$s\n" : match ( $this->tool_name ) {
 			'slack'                => "    ・ <%s|%s>\n",
 			'discord', 'chatwork'  => "    ・ %2\$s - %1\$s\n",
 		};

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -128,6 +128,17 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 	abstract public function generate_rinker_message( array $rinker_exists_items ): Sct_Slack | Sct_Discord | Sct_Chatwork | Sct_Error_Mail;
 
 	/**
+	 * Method to set notification type and original data.
+	 *
+	 * @param string       $notification_type Notification type.
+	 * @param array|object $original_data     Original data.
+	 */
+	public function set_notification_type_original_data( string $notification_type, object | array $original_data ): void {
+		$this->notification_type = $notification_type;
+		$this->original_data     = $original_data;
+	}
+
+	/**
 	 * Method to generate headers for each chat tool.
 	 *
 	 * @param string|null $header_emoji Header emoji.

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -114,10 +114,8 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 
 	/**
 	 * Abstract method to generate Rinker exists items message content to be sent to chat tools.
-	 *
-	 * @param array $rinker_exists_items Rinker exists items.
 	 */
-	abstract public function generate_rinker_message( array $rinker_exists_items ): Sct_Slack | Sct_Discord | Sct_Chatwork | Sct_Error_Mail;
+	abstract public function generate_rinker_message(): Sct_Slack | Sct_Discord | Sct_Chatwork | Sct_Error_Mail;
 
 	/**
 	 * Method to set notification type and original data.

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -133,9 +133,11 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 	 * @param string       $notification_type Notification type.
 	 * @param array|object $original_data     Original data.
 	 */
-	public function set_notification_type_original_data( string $notification_type, object | array $original_data ): void {
+	public function set_notification_type_original_data( string $notification_type, object | array $original_data ): Sct_Slack | Sct_Discord | Sct_Chatwork {
 		$this->notification_type = $notification_type;
 		$this->original_data     = $original_data;
+
+		return $this;
 	}
 
 	/**

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -360,4 +360,25 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 
 		return $this->logger( $status_code, $tool, $id );
 	}
+
+	/**
+	 * Method to call the error mail class.
+	 *
+	 * @param int    $error_code Error code.
+	 * @param string $tool_name  Chat tool name.
+	 */
+	private function call_error_mail_class( int $error_code, string $tool_name ): void {
+		$method = match ( $this->notification_type ) {
+			'update'        => 'generate_update_content',
+			'dev_notify'    => 'generate_developer_message',
+			'login_notify'  => 'generate_login_message',
+			'rinker_notify' => 'generate_rinker_message',
+			default         => 'generate_comment_content',
+		};
+
+		Sct_Error_Mail::get_instance()
+			?->set_error_code_tool_name( $error_code, $tool_name )
+			?->$method( $this->original_data )
+			?->send_mail();
+	}
 }

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -365,13 +365,7 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 	 * @param string $tool_name  Chat tool name.
 	 */
 	private function call_error_mail_class( int $error_code, string $tool_name ): void {
-		$method = match ( $this->notification_type ) {
-			'update'        => 'generate_update_content',
-			'dev_notify'    => 'generate_developer_message',
-			'login_notify'  => 'generate_login_message',
-			'rinker_notify' => 'generate_rinker_message',
-			default         => 'generate_comment_content',
-		};
+		$method = $this->notification_type;
 
 		Sct_Error_Mail::get_instance()
 			?->set_error_mail_properties( $error_code, $tool_name, $this->original_data )

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -375,7 +375,7 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 
 		Sct_Error_Mail::get_instance()
 			?->set_error_mail_properties( $error_code, $tool_name, $this->original_data )
-			?->$method( $this->original_data )
+			?->$method()
 			?->send_mail();
 	}
 }

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -287,15 +287,17 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 			0 => esc_html__( 'This message was sent by Send Chat Tools', 'send-chat-tools' ),
 			1 => esc_html__( 'WordPress Plugin Directory', 'send-chat-tools' ),
 			2 => esc_html__( 'Send Chat Tools Official Page', 'send-chat-tools' ),
+			3 => esc_html__( 'Possible that the message was not sent to the chat tool correctly.', 'send-chat-tools' ),
 		];
 
 		$wordpress_directory = $this->get_official_directory();
 		$official_web_site   = 'https://www.braveryk7.com/portfolio/send-chat-tools/';
 
 		return match ( $tool_name ) {
-			'slack'    => $message[0] . "\n" . '<' . $wordpress_directory . '|' . $message[1] . '> / <' . $official_web_site . '|' . $message[2] . '>',
-			'discord'  => '>>> ' . $message[0] . "\n\n" . $message[1] . ': <' . $wordpress_directory . '>' . "\n" . $message[2] . ': <' . $official_web_site . '>',
-			'chatwork' => '[hr]' . $message[0] . "\n" . $message[1] . ': ' . $wordpress_directory . "\n" . $message[2] . ': ' . $official_web_site,
+			'slack'      => $message[0] . "\n" . '<' . $wordpress_directory . '|' . $message[1] . '> / <' . $official_web_site . '|' . $message[2] . '>',
+			'discord'    => '>>> ' . $message[0] . "\n\n" . $message[1] . ': <' . $wordpress_directory . '>' . "\n" . $message[2] . ': <' . $official_web_site . '>',
+			'chatwork'   => '[hr]' . $message[0] . "\n" . $message[1] . ': ' . $wordpress_directory . "\n" . $message[2] . ': ' . $official_web_site,
+			'error_mail' => $message[0] . "\n\n" . $message[1] . ': ' . $wordpress_directory . "\n" . $message[2] . ': ' . $official_web_site . "\n\n" . $message[3],
 		};
 	}
 

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -94,10 +94,8 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 
 	/**
 	 * Abstract method to generate comment content to be sent to chat tools.
-	 *
-	 * @param object $comment Comment data.
 	 */
-	abstract public function generate_comment_content( object $comment, ): Sct_Slack | Sct_Discord | Sct_Chatwork | Sct_Error_Mail;
+	abstract public function generate_comment_content(): Sct_Slack | Sct_Discord | Sct_Chatwork | Sct_Error_Mail;
 
 	/**
 	 * Abstract method to generate update content to be sent to chat tools.
@@ -384,7 +382,7 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 		};
 
 		Sct_Error_Mail::get_instance()
-			?->set_error_code_tool_name( $error_code, $tool_name )
+			?->set_error_mail_properties( $error_code, $tool_name, $this->original_data )
 			?->$method( $this->original_data )
 			?->send_mail();
 	}

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -70,7 +70,7 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 	/**
 	 * Property that stores the original data before processing.
 	 *
-	 * @var array Original data.
+	 * @var object|array Original data.
 	 */
 	protected $original_data;
 

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -75,6 +75,13 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 	protected $original_data;
 
 	/**
+	 * Property that stores the flag of whether or not it is an error mail.
+	 *
+	 * @var bool Error mail flag.
+	 */
+	protected $is_error_mail = false;
+
+	/**
 	 * Constructor to obtain information necessary for content generation.
 	 */
 	protected function __construct() {

--- a/class/class-sct-slack.php
+++ b/class/class-sct-slack.php
@@ -48,13 +48,11 @@ class Sct_Slack extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Abstract method to create comment data to be sent to chat tools.
-	 *
-	 * @param object $comment Comment data.
 	 */
-	public function generate_comment_content( object $comment, ): Sct_Slack {
+	public function generate_comment_content(): Sct_Slack {
 		$article_title  = get_the_title( $this->original_data->comment_post_ID );
 		$article_url    = get_permalink( $this->original_data->comment_post_ID );
-		$comment_status = $this->generate_comment_approved_message( $this->tool_name, $comment );
+		$comment_status = $this->generate_comment_approved_message( $this->tool_name, $this->original_data );
 
 		$header_emoji     = ':mailbox_with_mail:';
 		$header_message   = $this->generate_header_message( $header_emoji, $this->get_send_text( 'comment', 'title' ) );

--- a/class/class-sct-slack.php
+++ b/class/class-sct-slack.php
@@ -146,16 +146,14 @@ class Sct_Slack extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Generate developer message for Slack.
-	 *
-	 * @param array $developer_message Developer message.
 	 */
-	public function generate_developer_message( array $developer_message ): Sct_Slack {
-		if ( isset( $developer_message['title'] ) && isset( $developer_message['message'] ) && array_key_exists( 'url', $developer_message ) ) {
-			$message_title = sprintf( $this->get_send_text( 'dev_notify', 'title' ), esc_html( $developer_message['title'] ), );
+	public function generate_developer_message(): Sct_Slack {
+		if ( isset( $this->original_data['title'] ) && isset( $this->original_data['message'] ) && array_key_exists( 'url', $this->original_data ) ) {
+			$message_title = sprintf( $this->get_send_text( 'dev_notify', 'title' ), esc_html( $this->original_data['title'] ), );
 			$content       = '';
 
 			$i = 0;
-			foreach ( $developer_message['message'] as $value ) {
+			foreach ( $this->original_data['message'] as $value ) {
 				if ( $i >= 50 ) {
 					break;
 				}
@@ -165,8 +163,8 @@ class Sct_Slack extends Sct_Generate_Content_Abstract {
 
 			$header_emoji    = ':tada:';
 			$header_message  = $this->generate_header_message( $header_emoji, $message_title );
-			$website_url     = $developer_message['url']['website'];
-			$update_page_url = $developer_message['url']['update_page'];
+			$website_url     = $this->original_data['url']['website'];
+			$update_page_url = $this->original_data['url']['update_page'];
 
 			$context = $this->generate_context( $this->tool_name );
 
@@ -216,7 +214,7 @@ class Sct_Slack extends Sct_Generate_Content_Abstract {
 					$this->divider(),
 					$this->context(
 						'mrkdwn',
-						$this->get_send_text( 'dev_notify', 'ignore' ) . ': ' . $developer_message['key'],
+						$this->get_send_text( 'dev_notify', 'ignore' ) . ': ' . $this->original_data['key'],
 					),
 					$this->context( 'mrkdwn', $context ),
 				],

--- a/class/class-sct-slack.php
+++ b/class/class-sct-slack.php
@@ -228,15 +228,13 @@ class Sct_Slack extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Generate login message for Slack.
-	 *
-	 * @param object $user User object.
 	 */
-	public function generate_login_message( object $user ): Sct_Slack {
+	public function generate_login_message(): Sct_Slack {
 		$header_emoji   = ':door:';
 		$header_message = $this->generate_header_message( $header_emoji, $this->get_send_text( 'login_notify', 'title' ) );
 
-		$user_name       = $user->data->user_login;
-		$user_email      = $user->data->user_email;
+		$user_name       = $this->original_data->data->user_login;
+		$user_email      = $this->original_data->data->user_email;
 		$login_user_name = '*' . $this->get_send_text( 'login_notify', 'user_name' ) . "*\n{$user_name}<$user_email>";
 
 		$now_date   = gmdate( 'Y-m-d H:i:s', strtotime( current_datetime()->format( 'Y-m-d H:i:s' ) ) );

--- a/class/class-sct-slack.php
+++ b/class/class-sct-slack.php
@@ -83,11 +83,10 @@ class Sct_Slack extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Generate update notifications for Slack.
-	 *
-	 * @param array $update_content Update data.
 	 */
-	public function generate_update_content( array $update_content ): Sct_Slack {
-		$plain_data     = $this->generate_plain_update_message( $update_content );
+	public function generate_update_content(): Sct_Slack {
+		$plain_data = $this->generate_plain_update_message( $this->original_data );
+
 		$header_emoji   = ':zap:';
 		$header_message = $this->generate_header_message( $header_emoji, $this->get_send_text( 'update', 'title' ) );
 		$update_message = $this->get_send_text( 'update', 'update' ) . "\n" . $this->get_send_text( 'update', 'page' ) . ": <{$plain_data->admin_url}>";

--- a/class/class-sct-slack.php
+++ b/class/class-sct-slack.php
@@ -52,19 +52,17 @@ class Sct_Slack extends Sct_Generate_Content_Abstract {
 	 * @param object $comment Comment data.
 	 */
 	public function generate_comment_content( object $comment, ): Sct_Slack {
-		$this->comment = $comment;
-
-		$article_title  = get_the_title( $comment->comment_post_ID );
-		$article_url    = get_permalink( $comment->comment_post_ID );
+		$article_title  = get_the_title( $this->original_data->comment_post_ID );
+		$article_url    = get_permalink( $this->original_data->comment_post_ID );
 		$comment_status = $this->generate_comment_approved_message( $this->tool_name, $comment );
 
 		$header_emoji     = ':mailbox_with_mail:';
 		$header_message   = $this->generate_header_message( $header_emoji, $this->get_send_text( 'comment', 'title' ) );
 		$comment_article  = '*' . $this->get_send_text( 'comment', 'article' ) . "*<{$article_url}|{$article_title}>";
-		$author           = '*' . $this->get_send_text( 'comment', 'commenter' ) . "*\n{$comment->comment_author}<{$comment->comment_author_email}>";
-		$date             = '*' . $this->get_send_text( 'constant', 'date' ) . "*\n{$comment->comment_date}";
-		$comment_content  = '*' . $this->get_send_text( 'comment', 'comment' ) . "*\n{$comment->comment_content}";
-		$comment_url      = '*' . $this->get_send_text( 'comment', 'url' ) . "*\n{$article_url}#comment-{$comment->comment_ID}";
+		$author           = '*' . $this->get_send_text( 'comment', 'commenter' ) . "*\n{$this->original_data->comment_author}<{$this->original_data->comment_author_email}>";
+		$date             = '*' . $this->get_send_text( 'constant', 'date' ) . "*\n{$this->original_data->comment_date}";
+		$comment_content  = '*' . $this->get_send_text( 'comment', 'comment' ) . "*\n{$this->original_data->comment_content}";
+		$comment_url      = '*' . $this->get_send_text( 'comment', 'url' ) . "*\n{$article_url}#comment-{$this->original_data->comment_ID}";
 		$comment_statuses = '*' . $this->get_send_text( 'comment', 'status' ) . "*\n{$comment_status}";
 		$context          = $this->generate_context( $this->tool_name );
 

--- a/class/class-sct-slack.php
+++ b/class/class-sct-slack.php
@@ -269,14 +269,12 @@ class Sct_Slack extends Sct_Generate_Content_Abstract {
 
 	/**
 	 * Generate Rinker exists items message for Slack.
-	 *
-	 * @param array $rinker_exists_items Rinker exists items.
 	 */
-	public function generate_rinker_message( array $rinker_exists_items ): Sct_Slack {
+	public function generate_rinker_message(): Sct_Slack {
 		$header_emoji   = ':package:';
 		$header_message = $this->generate_header_message( $header_emoji, $this->get_send_text( 'rinker_notify', 'title' ) );
 
-		$items = $this->generate_rinker_content( $rinker_exists_items );
+		$items = $this->generate_rinker_content( $this->original_data );
 
 		$after_message = $this->get_send_text( 'rinker_notify', 'temporary' ) . "\n" . $this->get_send_text( 'rinker_notify', 'resume' );
 

--- a/tests/SctErrorMailTest.php
+++ b/tests/SctErrorMailTest.php
@@ -43,13 +43,6 @@ class SctErrorMailTest extends PHPUnit\Framework\TestCase {
 	}
 
 	/**
-	 * TEST: update_contents()
-	 */
-	public function test_update_contents() {
-		$this->markTestIncomplete( 'This test is incomplete.' );
-	}
-
-	/**
 	 * TEST: send_mail()
 	 */
 	public function test_send_mail() {

--- a/tests/SctErrorMailTest.php
+++ b/tests/SctErrorMailTest.php
@@ -36,13 +36,6 @@ class SctErrorMailTest extends PHPUnit\Framework\TestCase {
 	}
 
 	/**
-	 * TEST: generate_contents()
-	 */
-	public function test_generate_contents() {
-		$this->markTestIncomplete( 'This test is incomplete.' );
-	}
-
-	/**
 	 * TEST: send_mail()
 	 */
 	public function test_send_mail() {

--- a/tests/SctErrorMailTest.php
+++ b/tests/SctErrorMailTest.php
@@ -20,6 +20,7 @@ class SctErrorMailTest extends PHPUnit\Framework\TestCase {
 			define( 'ABSPATH', '' );
 		}
 
+		require_once './class/class-sct-generate-content-abstract.php';
 		require_once './class/class-sct-error-mail.php';
 		require_once './tests/lib/wordpress-functions.php';
 	}
@@ -29,10 +30,6 @@ class SctErrorMailTest extends PHPUnit\Framework\TestCase {
 	 * Create instance.
 	 */
 	protected function setUp() :void {
-		$error_code     = 1;
-		$comment_id     = '1';
-		$tool_name      = 'slack';
-		$this->instance = new Sct_Error_Mail( $error_code, $comment_id, $tool_name );
 	}
 
 	/**


### PR DESCRIPTION
- refs #530 add return type -> Sct_Error_Mail
- refs #530 add properties
- refs #530 add abstract class require method
- refs #530 addc implementation generate_comment_content method
- refs #530 remove unused method
- refs #530 add set_error_code_tool_name method
- refs #530 remove test update_option function
- refs #530 fix implementation generate_comment_content method
- refs #530 add mail_to, mail_title properties
- refs #530 add parent constructor, set mail_to property -> constructor
- refs #530 add mail_title -> generate_ccomment_content method
- refs #530 fix args, use properties
- refs #530 remove blank line
- refs #530 remove unused property
- add ,  properties
- add call_error_mail_class method
- refs #530 fix use call_error_mail_class method
- refs #530 add set_notification_type_original_data method
- refs #530 fix return
- refs #530 fix use set_notification_type_original_data method
- refs #530 fix  type
- refs #530 fix use original data property
- refs #530 fix set_error_mail_properties method, use ->original_data
- refs #530 fix remove generate_comment_content args, Sct_Error_Mail class method name
- refs #530 remove call_chat_tool_class method ->  args
- refs #530 fix remove generate_comment_content arg, use ->original_data
- refs #530 remove unused arg
- refs #530 remove unused arg
- refs #530 remove unused arg, use ->original_data
- refs #530 remove unused arg
- refs #530 remove unused arg
- refs #530 fix use call_chat_tool_class method
- refs #530 remove unused arg, use ->original_data
- refs #530 remove unused arg
- refs #530 remove unused arg
- refs #530 remove unused arg, use ->original_data
- refs #530 remove unused arg
- refs #530 remove unused arg
- refs #530 remove unused arg, use ->original_data
- refs #530 remove unuser arg
- refs #530 add  var
- refs #530 add error_mail message
- refs #530 fix implementation generate_update_content method
- refs #530 fix implementation generate_developer_message
- refs #530 fix implementation generate_login_message
- refs #530 add  property
- refs #530 add use is_error_mail property
- refs #530 fix use is_error_mail property
- refs #530 fix implementation generate_rinker_message
- refs #530 remove unused method
- refs #530 remove unused test method
- refs #530 remove unused test method
- refs #530 fix require Sct_Generate_Content_Abstract, remove instance
