### PR TITLE
544 refactor Sct Error Mail

### DIFF
--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -128,7 +128,6 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 		$this->mail_title = sprintf( $this->get_send_text( 'dev_notify', 'title' ), esc_html( $this->original_data['title'] ), );
 
 		$content = '';
-		update_option( 'sct_dev_error', 'called' );
 
 		$i = 0;
 		foreach ( $this->original_data['message'] as $value ) {

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -81,7 +81,7 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 * Generate comment content for Error Mail.
 	 */
 	public function generate_comment_content(): Sct_Error_Mail {
-		$this->mail_title = esc_html__( 'You have received a new comment', 'send-chat-tools' );
+		$this->mail_title = $this->get_send_text( 'comment_notify', 'title' );
 
 		$article_title  = get_the_title( $this->original_data->comment_post_ID );
 		$article_url    = get_permalink( $this->original_data->comment_post_ID );

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -120,7 +120,9 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 * Generate developer content for Error Mail.
 	 */
 	public function generate_developer_content(): Sct_Error_Mail {
-		$this->mail_title = $this->site_name . '(' . $this->site_url . ') ' . sprintf( $this->get_send_text( 'dev_notify', 'title' ), esc_html( $this->original_data['title'] ), );
+		$this->mail_title = $this->generate_header_message(
+			header_message: sprintf( $this->get_send_text( 'dev_notify', 'title' ), esc_html( $this->original_data['title'] ) )
+		);
 
 		$content = '';
 

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -96,8 +96,7 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 			$this->get_send_text( 'comment_notify', 'comment' ) . ': ' . "\n" . $this->original_data->comment_content . "\n\n" .
 			$this->get_send_text( 'comment_notify', 'url' ) . ': ' . $article_url . '#comment-' . $this->original_data->comment_ID . "\n" .
 			$this->get_send_text( 'comment_notify', 'status' ) . ': ' . $comment_status . "\n\n" .
-			esc_html__( 'This message was sent by Send Chat Tools.', 'send-chat-tools' ) . "\n" .
-			esc_html__( 'Possible that the message was not sent to the chat tool correctly.', 'send-chat-tools' ) . "\n\n" .
+			$this->generate_context( 'error_mail' ) . "\n\n" .
 			esc_html__( 'Tool name:', 'send-chat-tools' ) . ucfirst( $this->tool_name ) . "\n" .
 			esc_html__( 'Error code:', 'send-chat-tools' ) . $this->error_code;
 

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -213,6 +213,13 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	}
 
 	/**
+	 * Method to generate tool name and error code for error mail.
+	 */
+	private function generate_error_message(): string {
+		return __( 'Tool name:', 'send-chat-tools' ) . ucfirst( $this->tool_name ) . "\n" . __( 'Error code:', 'send-chat-tools' ) . $this->error_code;
+	}
+
+	/**
 	 * Send mail.
 	 */
 	public function send_mail(): void {

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -107,10 +107,8 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 */
 	public function generate_update_content(): Sct_Error_Mail {
 		$this->mail_title = $this->get_send_text( 'update_notify', 'title' );
-
-		$raw_data = $this->generate_update_raw_data( $this->original_data );
-
-		$header_message = $this->site_name . '(' . $this->site_url . ') ' . $this->get_send_text( 'update_notify', 'title' );
+		$raw_data         = $this->generate_update_raw_data( $this->original_data );
+		$header_message   = $this->generate_header_message( header_message: $this->get_send_text( 'update_notify', 'title' ) );
 
 		$this->content =
 			$header_message . "\n\n" . $raw_data->core . $raw_data->themes . $raw_data->plugins .

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -86,7 +86,7 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 		$article_title  = get_the_title( $this->original_data->comment_post_ID );
 		$article_url    = get_permalink( $this->original_data->comment_post_ID );
 		$comment_status = $this->generate_comment_approved_message( $this->tool_name, $this->original_data );
-		$header_message = $this->site_name . '(' . $this->site_url . ') ' . $this->get_send_text( 'comment_notify', 'title' );
+		$header_message = $this->generate_header_message( header_message: $this->get_send_text( 'comment_notify', 'title' ) );
 
 		$this->content =
 			$header_message . "\n\n" .

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -81,15 +81,13 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 * Generate comment content for Error Mail.
 	 */
 	public function generate_comment_content(): Sct_Error_Mail {
-		$this->mail_title = $this->get_send_text( 'comment_notify', 'title' );
+		$this->mail_title = $this->generate_header_message( header_message: $this->get_send_text( 'comment_notify', 'title' ) );
 
 		$article_title  = get_the_title( $this->original_data->comment_post_ID );
 		$article_url    = get_permalink( $this->original_data->comment_post_ID );
 		$comment_status = $this->generate_comment_approved_message( $this->tool_name, $this->original_data );
-		$header_message = $this->generate_header_message( header_message: $this->get_send_text( 'comment_notify', 'title' ) );
 
 		$this->content =
-			$header_message . "\n\n" .
 			$this->get_send_text( 'comment_notify', 'article' ) . ': ' . $article_title . ' - ' . $article_url . "\n" .
 			$this->get_send_text( 'comment_notify', 'commenter' ) . ': ' . $this->original_data->comment_author . '<' . $this->original_data->comment_author_email . ">\n" .
 			$this->get_send_text( 'constant', 'date' ) . ': ' . $this->original_data->comment_date . "\n" .
@@ -106,12 +104,11 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 * Generate update content for Error Mail.
 	 */
 	public function generate_update_content(): Sct_Error_Mail {
-		$this->mail_title = $this->get_send_text( 'update_notify', 'title' );
+		$this->mail_title = $this->generate_header_message( header_message: $this->get_send_text( 'update_notify', 'title' ) );
 		$raw_data         = $this->generate_update_raw_data( $this->original_data );
-		$header_message   = $this->generate_header_message( header_message: $this->get_send_text( 'update_notify', 'title' ) );
 
 		$this->content =
-			$header_message . "\n\n" . $raw_data->core . $raw_data->themes . $raw_data->plugins .
+			$raw_data->core . $raw_data->themes . $raw_data->plugins .
 			$this->get_send_text( 'update_notify', 'update' ) . "\n" . $this->get_send_text( 'update_notify', 'page' ) . ': ' . $raw_data->admin_url . "\n\n" .
 			$this->generate_context( 'error_mail' ) . "\n" .
 			$this->generate_error_message();
@@ -123,7 +120,7 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 * Generate developer content for Error Mail.
 	 */
 	public function generate_developer_content(): Sct_Error_Mail {
-		$this->mail_title = sprintf( $this->get_send_text( 'dev_notify', 'title' ), esc_html( $this->original_data['title'] ), );
+		$this->mail_title = $this->site_name . '(' . $this->site_url . ') ' . sprintf( $this->get_send_text( 'dev_notify', 'title' ), esc_html( $this->original_data['title'] ), );
 
 		$content = '';
 
@@ -136,18 +133,16 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 			$i++;
 		}
 
-		$header_message  = $this->site_name . '(' . $this->site_url . ') ' . sprintf( $this->get_send_text( 'dev_notify', 'title' ), esc_html( $this->original_data['title'] ), );
 		$website_url     = $this->original_data['url']['website'];
 		$update_page_url = $this->original_data['url']['update_page'];
 
-		$title        = $header_message . "\n\n";
 		$main_content = $content . "\n";
 		$website      = $website_url ? $this->get_send_text( 'dev_notify', 'website' ) . ': <' . $website_url . ">\n" : null;
 		$update_page  = $update_page_url ? $this->get_send_text( 'dev_notify', 'detail' ) . ': <' . $update_page_url . ">\n" : null;
 		$ignore       = "\n" . $this->get_send_text( 'dev_notify', 'ignore' ) . ': ' . $this->original_data['key'] . "\n";
 
 		$this->content =
-			$title . $main_content . $website . $update_page . $ignore . "\n" .
+			$main_content . $website . $update_page . $ignore . "\n" .
 			$this->generate_context( 'error_mail' ) . "\n" .
 			$this->generate_error_message();
 
@@ -158,7 +153,7 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 * Generate login content for Error Mail.
 	 */
 	public function generate_login_content(): Sct_Error_Mail {
-		$this->mail_title = $this->get_send_text( 'login_notify', 'title' );
+		$this->mail_title = $this->generate_header_message( header_message: $this->get_send_text( 'login_notify', 'title' ) );
 
 		$user_name       = $this->original_data->data->user_login;
 		$user_email      = $this->original_data->data->user_email;
@@ -174,7 +169,6 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 		$login_ip_address = $this->get_send_text( 'login_notify', 'ip_address' ) . ": {$ip_address}";
 
 		$this->content =
-			$this->site_name . '(' . $this->site_url . ') ' . $this->mail_title . "\n\n" .
 			$login_user_name . "\n" . $login_date . "\n" . $login_env . "\n" . $login_ip_address . "\n\n" .
 			$this->get_send_text( 'login_notify', 'unauthorized_login' ) . "\n" .
 			$this->get_send_text( 'login_notify', 'disconnect' ) . "\n" .
@@ -189,14 +183,13 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 	 * Generate Rinker content for Error Mail.
 	 */
 	public function generate_rinker_content(): Sct_Error_Mail {
-		$this->mail_title = $this->get_send_text( 'rinker_notify', 'title' );
+		$this->mail_title = $this->generate_header_message( header_message: $this->get_send_text( 'rinker_notify', 'title' ) );
 
 		$items = $this->format_rinker_items( $this->original_data );
 
 		$after_message = $this->get_send_text( 'rinker_notify', 'temporary' ) . "\n" . $this->get_send_text( 'rinker_notify', 'resume' );
 
 		$this->content =
-			$this->site_name . '(' . $this->site_url . ') ' . $this->mail_title . "\n\n" .
 			$items . "\n\n" . $after_message . "\n\n" .
 			$this->generate_context( 'error_mail' ) . "\n" .
 			$this->generate_error_message();

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -97,8 +97,7 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 			$this->get_send_text( 'comment_notify', 'url' ) . ': ' . $article_url . '#comment-' . $this->original_data->comment_ID . "\n" .
 			$this->get_send_text( 'comment_notify', 'status' ) . ': ' . $comment_status . "\n\n" .
 			$this->generate_context( 'error_mail' ) . "\n\n" .
-			esc_html__( 'Tool name:', 'send-chat-tools' ) . ucfirst( $this->tool_name ) . "\n" .
-			esc_html__( 'Error code:', 'send-chat-tools' ) . $this->error_code;
+			$this->generate_error_message();
 
 		return $this;
 	}
@@ -117,8 +116,7 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 			$header_message . "\n\n" . $raw_data->core . $raw_data->themes . $raw_data->plugins .
 			$this->get_send_text( 'update_notify', 'update' ) . "\n" . $this->get_send_text( 'update_notify', 'page' ) . ': ' . $raw_data->admin_url . "\n\n" .
 			$this->generate_context( 'error_mail' ) . "\n" .
-			esc_html__( 'Tool name:', 'send-chat-tools' ) . ucfirst( $this->tool_name ) . "\n" .
-			esc_html__( 'Error code:', 'send-chat-tools' ) . $this->error_code;
+			$this->generate_error_message();
 
 		return $this;
 	}
@@ -154,8 +152,7 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 		$this->content =
 			$title . $main_content . $website . $update_page . $ignore . "\n" .
 			$this->generate_context( 'error_mail' ) . "\n" .
-			esc_html__( 'Tool name:', 'send-chat-tools' ) . ucfirst( $this->tool_name ) . "\n" .
-			esc_html__( 'Error code:', 'send-chat-tools' ) . $this->error_code;
+			$this->generate_error_message();
 
 		return $this;
 	}
@@ -186,8 +183,7 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 			$this->get_send_text( 'login_notify', 'disconnect' ) . "\n" .
 			$this->site_url . '/wp-admin/profile.php' . "\n\n" .
 			$this->generate_context( 'error_mail' ) . "\n" .
-			esc_html__( 'Tool name:', 'send-chat-tools' ) . ucfirst( $this->tool_name ) . "\n" .
-			esc_html__( 'Error code:', 'send-chat-tools' ) . $this->error_code;
+			$this->generate_error_message();
 
 		return $this;
 	}
@@ -206,8 +202,7 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 			$this->site_name . '(' . $this->site_url . ') ' . $this->mail_title . "\n\n" .
 			$items . "\n\n" . $after_message . "\n\n" .
 			$this->generate_context( 'error_mail' ) . "\n" .
-			esc_html__( 'Tool name:', 'send-chat-tools' ) . ucfirst( $this->tool_name ) . "\n" .
-			esc_html__( 'Error code:', 'send-chat-tools' ) . $this->error_code;
+			$this->generate_error_message();
 
 		return $this;
 	}

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -145,9 +145,10 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 	 */
 	protected function generate_header_message( string $header_emoji = null, string $header_message ): string {
 		return match ( $this->tool_name ) {
-			'slack'    => "{$header_emoji} {$this->site_name}({$this->site_url}) " . $header_message,
-			'discord'  => "{$header_emoji} __***{$this->site_name}({$this->site_url}) " . $header_message . '***__',
-			'chatwork' => '[title]' . $this->site_name . '(' . $this->site_url . ') ' . $header_message . '[/title]',
+			'slack'      => "{$header_emoji} {$this->site_name}({$this->site_url}) " . $header_message,
+			'discord'    => "{$header_emoji} __***{$this->site_name}({$this->site_url}) " . $header_message . '***__',
+			'chatwork'   => '[title]' . $this->site_name . '(' . $this->site_url . ') ' . $header_message . '[/title]',
+			'error_mail' => "{$this->site_name}({$this->site_url}) {$$header_message}",
 		};
 	}
 

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -279,6 +279,10 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 				'temporary' => __( 'Amazon and Rakuten may have temporarily withdrawn sales.', 'send-chat-tools' ),
 				'resume'    => __( 'Note that sales may resume after this notice is received, and there is no promise of an end of sales.', 'send-chat-tools' ),
 			],
+			'error_mail'     => [
+				'tool_name'  => __( 'Tool name', 'send-chat-tools' ),
+				'error_code' => __( 'Error code', 'send-chat-tools' ),
+			],
 		];
 
 		return $message[ $type ][ $param ];


### PR DESCRIPTION
- refs #544 fix use get_send_text method
- refs #544 add error_mail texts
- refs #544 fix use generate_contexy method
- refs #544 add generate_error_message method
- refs #544 fix use generate_error_message method
- refs #544 remove dev update option
- refs #544 add error_mail match value
- refs #544 fix use generate_header_message method
- refs #544 fix use generate_header_message method
- refs #544 remove header_message, use generate_header_message for mail_title
- refs #544 fix use generate_header_message method
