### PR TITLE
594 fix get wpcron event name method

### DIFF
--- a/class/class-sct-activate.php
+++ b/class/class-sct-activate.php
@@ -119,7 +119,8 @@ class Sct_Activate extends Sct_Base {
 			delete_option( self::add_prefix( $option_name ) );
 		}
 
-		foreach ( [ self::get_wpcron_event_name(), self::add_prefix( 'rinker_discontinued_items_check' ) ] as $cron_event ) {
+		foreach ( [ 'update_notify', 'rinker_notify' ] as $event_type ) {
+			$cron_event = self::get_wpcron_event_name( $event_type );
 			if ( wp_get_scheduled_event( $cron_event ) ) {
 				wp_clear_scheduled_hook( $cron_event );
 			}

--- a/class/class-sct-base.php
+++ b/class/class-sct-base.php
@@ -220,7 +220,7 @@ class Sct_Base {
 	public static function get_wpcron_event_name( string $event_type ): string {
 		return match ( $event_type ) {
 			'update_notify' => self::add_prefix( self::WP_CRON_EVENT_NAME ),
-			'rinker_notify' => self::add_prefix( 'rinker_discontinued_items_check' ),
+			'rinker_notify' => self::add_prefix( self::WP_CRON_RINKER_NOTIFY_EVENT_NAME ),
 		};
 	}
 

--- a/class/class-sct-base.php
+++ b/class/class-sct-base.php
@@ -33,7 +33,8 @@ class Sct_Base {
 
 	protected const ENCRYPT_METHOD = 'AES-256-CBC';
 
-	private const WP_CRON_EVENT_NAME = 'update_check';
+	private const WP_CRON_EVENT_NAME               = 'update_check';
+	private const WP_CRON_RINKER_NOTIFY_EVENT_NAME = 'rinker_discontinued_items_check';
 
 	public const OPTIONS_COLUMN = [
 		'options',

--- a/class/class-sct-base.php
+++ b/class/class-sct-base.php
@@ -33,7 +33,7 @@ class Sct_Base {
 
 	protected const ENCRYPT_METHOD = 'AES-256-CBC';
 
-	public const WP_CRON_EVENT_NAME = 'update_check';
+	private const WP_CRON_EVENT_NAME = 'update_check';
 
 	public const OPTIONS_COLUMN = [
 		'options',

--- a/class/class-sct-base.php
+++ b/class/class-sct-base.php
@@ -213,9 +213,14 @@ class Sct_Base {
 
 	/**
 	 * Get WP-cron event name.
+	 *
+	 * @param string $event_type Event type.
 	 */
-	public static function get_wpcron_event_name(): string {
-		return self::add_prefix( self::WP_CRON_EVENT_NAME );
+	public static function get_wpcron_event_name( string $event_type ): string {
+		return match ( $event_type ) {
+			'update_notify' => self::add_prefix( self::WP_CRON_EVENT_NAME ),
+			'rinker_notify' => self::add_prefix( 'rinker_discontinued_items_check' ),
+		};
 	}
 
 	/**

--- a/class/class-sct-check-rinker.php
+++ b/class/class-sct-check-rinker.php
@@ -29,7 +29,7 @@ class Sct_Check_Rinker extends Sct_Base {
 	 * WordPress hook.
 	 */
 	public function __construct() {
-		$this->cron_event_name = $this->add_prefix( 'rinker_discontinued_items_check' );
+		$this->cron_event_name = $$this->get_wpcron_event_name( 'rinker_notify' );
 		add_action( $this->cron_event_name, [ $this, 'controller' ] );
 		add_action( 'admin_init', [ $this, 'check_cron_time' ] );
 		add_action( 'rest_api_init', [ $this, 'register_rest_api' ] );

--- a/class/class-sct-check-rinker.php
+++ b/class/class-sct-check-rinker.php
@@ -29,7 +29,7 @@ class Sct_Check_Rinker extends Sct_Base {
 	 * WordPress hook.
 	 */
 	public function __construct() {
-		$this->cron_event_name = $$this->get_wpcron_event_name( 'rinker_notify' );
+		$this->cron_event_name = $this->get_wpcron_event_name( 'rinker_notify' );
 		add_action( $this->cron_event_name, [ $this, 'controller' ] );
 		add_action( 'admin_init', [ $this, 'check_cron_time' ] );
 		add_action( 'rest_api_init', [ $this, 'register_rest_api' ] );

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -30,7 +30,7 @@ class Sct_Check_Update extends Sct_Base {
 	 * Add WP-Cron.
 	 */
 	public function __construct() {
-		$this->cron_event_name = $this->add_prefix( 'update_check' );
+		$this->cron_event_name = $this->get_wpcron_event_name( 'update_notify' );
 		add_action( $this->add_prefix( 'update_check' ), [ $this, 'controller' ] );
 		add_action( 'admin_init', [ $this, 'check_cron_time' ] );
 	}


### PR DESCRIPTION
- refs #594 fix use arg, add rinker_notify
- refs #594 fix use get_wpcron_event_name args
- refs #594 fix modifire
- refs #594 add WP_CRON_RINKER_NOTIFY_EVENT_NAME property
- refs #594 fix use WP_CRON_RINKER_NOTIFY_EVENT_NAME property
- refs #594 fix use get_wpcron_event_name method
- refs #594 fix use get_wpcron_event_name method
- refs #594 fix call
