### PR TITLE
v1.5.3 feature

### DIFF
--- a/class/class-sct-activate.php
+++ b/class/class-sct-activate.php
@@ -119,7 +119,8 @@ class Sct_Activate extends Sct_Base {
 			delete_option( self::add_prefix( $option_name ) );
 		}
 
-		foreach ( [ self::get_wpcron_event_name(), self::add_prefix( 'rinker_discontinued_items_check' ) ] as $cron_event ) {
+		foreach ( [ 'update_notify', 'rinker_notify' ] as $event_type ) {
+			$cron_event = self::get_wpcron_event_name( $event_type );
 			if ( wp_get_scheduled_event( $cron_event ) ) {
 				wp_clear_scheduled_hook( $cron_event );
 			}

--- a/class/class-sct-activate.php
+++ b/class/class-sct-activate.php
@@ -118,8 +118,11 @@ class Sct_Activate extends Sct_Base {
 		foreach ( self::OPTIONS_COLUMN as $option_name ) {
 			delete_option( self::add_prefix( $option_name ) );
 		}
-		if ( wp_get_scheduled_event( self::get_wpcron_event_name() ) ) {
-			wp_clear_scheduled_hook( self::get_wpcron_event_name() );
+
+		foreach ( [ self::get_wpcron_event_name(), self::add_prefix( 'rinker_discontinued_items_check' ) ] as $cron_event ) {
+			if ( wp_get_scheduled_event( $cron_event ) ) {
+				wp_clear_scheduled_hook( $cron_event );
+			}
 		}
 	}
 

--- a/class/class-sct-base.php
+++ b/class/class-sct-base.php
@@ -24,7 +24,7 @@ class Sct_Base {
 	protected const PLUGIN_FILE          = self::PLUGIN_SLUG . '.php';
 	protected const API_NAME             = self::PLUGIN_SLUG;
 	protected const API_VERSION          = 'v1';
-	protected const VERSION              = '1.5.2';
+	protected const VERSION              = '1.5.3';
 	protected const OPTIONS_COLUMN_NAME  = 'options';
 	protected const REQUIRED_PHP_VERSION = '8.0.0';
 	protected const OFFICIAL_DIRECTORY   = 'https://wordpress.org/plugins/' . self::PLUGIN_SLUG . '/';
@@ -255,14 +255,21 @@ class Sct_Base {
 			'type'    => 'plugin',
 			'title'   => esc_html__( 'Send Chat Tools', 'send-chat-tools' ),
 			'message' => [
-				__( 'Updated to version 1.5.2!', 'send-chat-tools' ),
+				__( 'Updated to version 1.5.3!', 'send-chat-tools' ),
 				__( 'Here are the main changes...', 'send-chat-tools' ),
 				'',
 				__( 'Important:', 'send-chat-tools' ),
 				__( '- PHP8.0 is required for v1.4.0 and later.', 'send-chat-tools' ),
 				'',
+				__( 'Feature:', 'send-chat-tools' ),
+				__( '- Added JIN:R to update notifications.', 'send-chat-tools' ),
+				'',
+				__( 'Improvements:', 'send-chat-tools' ),
+				__( '- The process of generating and saving logs has been changed.', 'send-chat-tools' ),
+				'',
 				__( 'Fixes:', 'send-chat-tools' ),
-				__( '- Fixed an issue where notification was sent despite the end-of-sale flag not being set in the Rinker end-of-sale notification.', 'send-chat-tools' ),
+				__( '- Fixed problem with update notifications not being sent when Cocoon is enabled.', 'send-chat-tools' ),
+				__( '- Fixed to remove WP-Cron from Rinker notifications upon uninstallation.', 'send-chat-tools' ),
 			],
 			'url'     => [
 				'website'     => 'https://www.braveryk7.com/portfolio/send-chat-tools/',

--- a/class/class-sct-base.php
+++ b/class/class-sct-base.php
@@ -33,7 +33,8 @@ class Sct_Base {
 
 	protected const ENCRYPT_METHOD = 'AES-256-CBC';
 
-	public const WP_CRON_EVENT_NAME = 'update_check';
+	private const WP_CRON_EVENT_NAME               = 'update_check';
+	private const WP_CRON_RINKER_NOTIFY_EVENT_NAME = 'rinker_discontinued_items_check';
 
 	public const OPTIONS_COLUMN = [
 		'options',
@@ -213,9 +214,14 @@ class Sct_Base {
 
 	/**
 	 * Get WP-cron event name.
+	 *
+	 * @param string $event_type Event type.
 	 */
-	public static function get_wpcron_event_name(): string {
-		return self::add_prefix( self::WP_CRON_EVENT_NAME );
+	public static function get_wpcron_event_name( string $event_type ): string {
+		return match ( $event_type ) {
+			'update_notify' => self::add_prefix( self::WP_CRON_EVENT_NAME ),
+			'rinker_notify' => self::add_prefix( self::WP_CRON_RINKER_NOTIFY_EVENT_NAME ),
+		};
 	}
 
 	/**

--- a/class/class-sct-base.php
+++ b/class/class-sct-base.php
@@ -90,6 +90,7 @@ class Sct_Base {
 		'Cocoon'    => 'puc_external_updates_theme-cocoon-master',
 		'SANGO'     => 'puc_external_updates_theme-sango-theme',
 		'THE SONIC' => 'puc_external_updates_theme-tsnc-main-theme-updater',
+		'JIN:R'     => 'external_theme_updates-jinr',
 	];
 	protected const PLUGIN_OPTION_NAME = [
 		'Rinker'                     => 'external_updates-yyi-rinker',

--- a/class/class-sct-base.php
+++ b/class/class-sct-base.php
@@ -87,7 +87,7 @@ class Sct_Base {
 	];
 
 	protected const THEME_OPTION_NAME  = [
-		'Cocoon'    => 'external_theme_updates-cocoon-master',
+		'Cocoon'    => 'puc_external_updates_theme-cocoon-master',
 		'SANGO'     => 'puc_external_updates_theme-sango-theme',
 		'THE SONIC' => 'puc_external_updates_theme-tsnc-main-theme-updater',
 	];

--- a/class/class-sct-check-rinker.php
+++ b/class/class-sct-check-rinker.php
@@ -29,7 +29,7 @@ class Sct_Check_Rinker extends Sct_Base {
 	 * WordPress hook.
 	 */
 	public function __construct() {
-		$this->cron_event_name = $this->add_prefix( 'rinker_discontinued_items_check' );
+		$this->cron_event_name = $this->get_wpcron_event_name( 'rinker_notify' );
 		add_action( $this->cron_event_name, [ $this, 'controller' ] );
 		add_action( 'admin_init', [ $this, 'check_cron_time' ] );
 		add_action( 'rest_api_init', [ $this, 'register_rest_api' ] );

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -30,7 +30,7 @@ class Sct_Check_Update extends Sct_Base {
 	 * Add WP-Cron.
 	 */
 	public function __construct() {
-		$this->cron_event_name = $this->add_prefix( 'update_check' );
+		$this->cron_event_name = $this->get_wpcron_event_name( 'update_notify' );
 		add_action( $this->add_prefix( 'update_check' ), [ $this, 'controller' ] );
 		add_action( 'admin_init', [ $this, 'check_cron_time' ] );
 	}

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -331,22 +331,9 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 			$result = wp_remote_post( $url, $this->header );
 
 			if ( ctype_digit( $notification_type ) ) {
-				$logs = [
-					$this->original_data->comment_date => [
-						'id'      => $this->original_data->comment_ID,
-						'author'  => $this->original_data->comment_author,
-						'email'   => $this->original_data->comment_author_email,
-						'url'     => $this->original_data->comment_author_url,
-						'comment' => $this->original_data->comment_content,
-						'status'  => $result['response']['code'],
-					],
-				];
-
-				if ( '3' <= count( $sct_options[ $tool_name ]['log'] ) ) {
-					array_pop( $sct_options[ $tool_name ]['log'] );
-				}
-				$sct_options[ $tool_name ]['log'] = $logs + $sct_options[ $tool_name ]['log'];
-				$this->set_sct_options( $sct_options );
+				Sct_Logger::get_instance()
+					?->individual_log( $this->original_data, $result['response']['code'], $tool_name, $sct_options )
+					?->is_saved();
 			}
 		}
 

--- a/class/class-sct-logger.php
+++ b/class/class-sct-logger.php
@@ -108,4 +108,35 @@ class Sct_Logger extends Sct_Base {
 	public function is_saved() {
 		return $this->result;
 	}
+
+	/**
+	 * Method for storing individual logs.
+	 *
+	 * @param object $original_data Comment data.
+	 * @param int    $status_code   HTTP status code.
+	 * @param string $tool_name     Use tool name.
+	 * @param array  $sct_options   Send Chat Tools options.
+	 */
+	public function individual_log( object $original_data, int $status_code, string $tool_name, array $sct_options ) {
+		$logs = [
+			$original_data->comment_date => [
+				'id'      => $original_data->comment_ID,
+				'author'  => $original_data->comment_author,
+				'email'   => $original_data->comment_author_email,
+				'url'     => $original_data->comment_author_url,
+				'comment' => $original_data->comment_content,
+				'status'  => $status_code,
+			],
+		];
+
+		if ( '3' <= count( $sct_options[ $tool_name ]['log'] ) ) {
+			array_pop( $sct_options[ $tool_name ]['log'] );
+		}
+
+		$sct_options[ $tool_name ]['log'] = $logs + $sct_options[ $tool_name ]['log'];
+
+		$this->result = $this->set_sct_options( $sct_options );
+
+		return $this;
+	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: send chat tools, send, chat, slack, discord, chatwork, update
 Requires at least: 5.7.2
 Tested up to: 6.2
 Requires PHP: 8.0.0
-Stable tag: 1.5.2
+Stable tag: 1.5.3
 License: GpLv2 or later
 License URI: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
 
@@ -15,6 +15,25 @@ Currently, it sends an announcement when a comment is received.
 You can instantly check comments that you didn't notice with the default email notification. 
 
 === Changelog ===
+
+= 1.5.3 =
+
+Important:
+
+* PHP8.0 is required for v1.4.0 and later.
+
+Feature:
+
+* Added JIN:R to update notifications.
+
+Improvements:
+
+* The process of generating and saving logs has been changed.
+
+Fixes:
+
+* Fixed problem with update notifications not being sent when Cocoon is enabled.
+* Fixed to remove WP-Cron from Rinker notifications upon uninstallation.
 
 = 1.5.2 =
 

--- a/send-chat-tools.php
+++ b/send-chat-tools.php
@@ -3,7 +3,7 @@
  * Plugin Name: Send Chat Tools
  * Plugin URI:  https://www.braveryk7.com/
  * Description: A plugin that allows you to send WordPress announcements to chat tools.
- * Version:     1.5.2
+ * Version:     1.5.3
  * Author:      Ken-chan
  * Author URI:  https://twitter.com/braveryk7
  * Text Domain: send-chat-tools


### PR DESCRIPTION
- refs #586 fix process if update_themes is PHP_Incomplete_Class
- refs #586 fix cocoon theme update key
- refs #586 remove develop update_option
- refs #588 fix use Sct_Logger instance
- refs #588 add individual_log method
- refs #590 add THEME_OPTION_NAME -> JIN:R
- refs #592 fix uninstall_options -> add rinker_notify cron delete process
- refs #594 fix use arg, add rinker_notify
- refs #594 fix use get_wpcron_event_name args
- refs #594 fix modifire
- refs #594 add WP_CRON_RINKER_NOTIFY_EVENT_NAME property
- refs #594 fix use WP_CRON_RINKER_NOTIFY_EVENT_NAME property
- refs #594 fix use get_wpcron_event_name method
- refs #594 fix use get_wpcron_event_name method
- refs #594 fix call
- refs #596 fix developer messege for v1.5.3
- refs #596 fix version -> v1.5.3
- refs #596 fix version -> v1.5.3
- refs #596 fix version -> v1.5.3
- refs #596 add v1.5.3 update log
