### PR TITLE
601 fix update wpcs

### DIFF
--- a/class/class-sct-activate.php
+++ b/class/class-sct-activate.php
@@ -240,7 +240,7 @@ class Sct_Activate extends Sct_Base {
 				update_option( $this->add_prefix( 'logs' ), $sct_logs );
 
 				$sql = 'DROP TABLE IF EXISTS ' . $wpdb->prefix . self::TABLE_NAME;
-				$wpdb->query( "${sql}" );
+				$wpdb->query( "${sql}" ); // phpcs:ignore
 			}
 		}
 	}

--- a/class/class-sct-activate.php
+++ b/class/class-sct-activate.php
@@ -216,7 +216,7 @@ class Sct_Activate extends Sct_Base {
 		 */
 		if ( ! get_option( $this->add_prefix( 'logs' ) ) ) {
 			global $wpdb;
-			$get_table = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $this->get_table_name() ) ); // db call ok; no-cache ok.
+			$get_table = $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $this->get_table_name() ) ); // phpcs:ignore
 
 			if ( $get_table ) {
 				$result = $wpdb->get_results( 'SELECT * FROM wp_sct' ); // phpcs:ignore
@@ -240,7 +240,7 @@ class Sct_Activate extends Sct_Base {
 				update_option( $this->add_prefix( 'logs' ), $sct_logs );
 
 				$sql = 'DROP TABLE IF EXISTS ' . $wpdb->prefix . self::TABLE_NAME;
-				$wpdb->query( "${sql}" ); // db call ok; no-cache ok.
+				$wpdb->query( "${sql}" );
 			}
 		}
 	}

--- a/class/class-sct-admin-page.php
+++ b/class/class-sct-admin-page.php
@@ -36,7 +36,7 @@ class Sct_Admin_Page extends Sct_Base {
 		add_options_page(
 			__( 'Send Chat Tools', 'send-chat-tools' ),
 			__( 'Send Chat Tools', 'send-chat-tools' ),
-			'administrator',
+			'manage_options',
 			self::PLUGIN_SLUG,
 			[ $this, 'settings_page' ],
 		);
@@ -49,7 +49,7 @@ class Sct_Admin_Page extends Sct_Base {
 			add_options_page(
 				__( 'Old Send Chat Tools', 'send-chat-tools' ),
 				__( 'Old Send Chat Tools', 'send-chat-tools' ),
-				'administrator',
+				'manage_options',
 				'send-chat-tools-settings',
 				[ $this, 'old_settings_page' ]
 			);
@@ -130,7 +130,7 @@ class Sct_Admin_Page extends Sct_Base {
 	 * Return WordPress  administrator permission.
 	 */
 	public function get_wordpress_permission(): bool {
-		return current_user_can( 'administrator' );
+		return current_user_can( 'manage_options' );
 	}
 
 	/**

--- a/class/class-sct-chatwork.php
+++ b/class/class-sct-chatwork.php
@@ -106,7 +106,7 @@ class Sct_Chatwork extends Sct_Generate_Content_Abstract {
 					break;
 				}
 				$content .= $value . "\n";
-				$i++;
+				++$i;
 			}
 
 			$header_message  = $this->generate_header_message( header_message: $message_title );

--- a/class/class-sct-check-comment.php
+++ b/class/class-sct-check-comment.php
@@ -43,7 +43,7 @@ class Sct_Check_Comment extends Sct_Base {
 				$this->logger( 1001, $tool, '1' );
 			} elseif ( 'chatwork' === $tool && ( $sct_options[ $tool ]['use'] && empty( $sct_options[ $tool ]['room_id'] ) ) ) {
 				$this->logger( 1002, 'chatwork', '1' );
-			};
+			}
 		}
 	}
 

--- a/class/class-sct-check-login.php
+++ b/class/class-sct-check-login.php
@@ -43,7 +43,7 @@ class Sct_Check_Login extends Sct_Base {
 				$this->logger( 1001, $tool, '1' );
 			} elseif ( 'chatwork' === $tool && ( $sct_options[ $tool ]['use'] && empty( $sct_options[ $tool ]['room_id'] ) ) ) {
 				$this->logger( 1002, 'chatwork', '1' );
-			};
+			}
 		}
 	}
 }

--- a/class/class-sct-check-rinker.php
+++ b/class/class-sct-check-rinker.php
@@ -104,17 +104,15 @@ class Sct_Check_Rinker extends Sct_Base {
 
 			if ( ! $next_schedule ) {
 				wp_schedule_event( $datetime_timestamp, 'daily', $this->cron_event_name );
-			} else {
-				if ( isset( $sct_options['rinker_cron_time'] ) ) {
-					if ( $next_schedule->timestamp !== $datetime_timestamp ) {
-						$datetime_timestamp <= time() ? $datetime_timestamp = strtotime( '+1 day', $datetime_timestamp ) : $datetime_timestamp;
-						wp_clear_scheduled_hook( $this->cron_event_name );
-						wp_schedule_event( $datetime_timestamp, 'daily', $this->cron_event_name );
-					}
-				} else {
-					$sct_options['rinker_cron_time'] = '19:00';
-					$this->set_sct_options( $sct_options );
+			} elseif ( isset( $sct_options['rinker_cron_time'] ) ) {
+				if ( $next_schedule->timestamp !== $datetime_timestamp ) {
+					$datetime_timestamp <= time() ? $datetime_timestamp = strtotime( '+1 day', $datetime_timestamp ) : $datetime_timestamp;
+					wp_clear_scheduled_hook( $this->cron_event_name );
+					wp_schedule_event( $datetime_timestamp, 'daily', $this->cron_event_name );
 				}
+			} else {
+				$sct_options['rinker_cron_time'] = '19:00';
+				$this->set_sct_options( $sct_options );
 			}
 		} else {
 			wp_clear_scheduled_hook( $this->cron_event_name );

--- a/class/class-sct-check-rinker.php
+++ b/class/class-sct-check-rinker.php
@@ -148,7 +148,7 @@ class Sct_Check_Rinker extends Sct_Base {
 			[
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => [ $this, 'register_rinker_status' ],
-				'permission_callback' => fn() => current_user_can( 'administrator' ),
+				'permission_callback' => fn() => current_user_can( 'manage_options' ),
 			]
 		);
 	}

--- a/class/class-sct-check-rinker.php
+++ b/class/class-sct-check-rinker.php
@@ -53,7 +53,7 @@ class Sct_Check_Rinker extends Sct_Base {
 					$this->logger( 1001, $tool, '1' );
 				} elseif ( 'chatwork' === $tool && ( $sct_options[ $tool ]['use'] && empty( $sct_options[ $tool ]['room_id'] ) ) ) {
 					$this->logger( 1002, 'chatwork', '1' );
-				};
+				}
 			}
 		}
 	}

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -60,7 +60,7 @@ class Sct_Check_Update extends Sct_Base {
 					$this->logger( 1001, $tool, '1' );
 				} elseif ( 'chatwork' === $tool && ( $sct_options[ $tool ]['use'] && empty( $sct_options[ $tool ]['room_id'] ) ) ) {
 					$this->logger( 1002, 'chatwork', '1' );
-				};
+				}
 			}
 		}
 	}

--- a/class/class-sct-check-update.php
+++ b/class/class-sct-check-update.php
@@ -183,17 +183,15 @@ class Sct_Check_Update extends Sct_Base {
 
 		if ( ! $next_schedule ) {
 			wp_schedule_event( $datetime_timestamp, 'daily', $this->cron_event_name );
-		} else {
-			if ( isset( $sct_options['cron_time'] ) ) {
-				if ( $next_schedule->timestamp !== $datetime_timestamp ) {
-					$datetime_timestamp <= time() ? $datetime_timestamp = strtotime( '+1 day', $datetime_timestamp ) : $datetime_timestamp;
-					wp_clear_scheduled_hook( $this->cron_event_name );
-					wp_schedule_event( $datetime_timestamp, 'daily', $this->cron_event_name );
-				}
-			} else {
-				$sct_options['cron_time'] = '18:00';
-				$this->set_sct_options( $sct_options );
+		} elseif ( isset( $sct_options['cron_time'] ) ) {
+			if ( $next_schedule->timestamp !== $datetime_timestamp ) {
+				$datetime_timestamp <= time() ? $datetime_timestamp = strtotime( '+1 day', $datetime_timestamp ) : $datetime_timestamp;
+				wp_clear_scheduled_hook( $this->cron_event_name );
+				wp_schedule_event( $datetime_timestamp, 'daily', $this->cron_event_name );
 			}
+		} else {
+			$sct_options['cron_time'] = '18:00';
+			$this->set_sct_options( $sct_options );
 		}
 	}
 }

--- a/class/class-sct-developer-notify.php
+++ b/class/class-sct-developer-notify.php
@@ -46,7 +46,7 @@ class Sct_Developer_Notify extends Sct_Base {
 							$this->logger( 1001, $tool, '1' );
 						} elseif ( 'chatwork' === $tools && ( $sct_options[ $tool ]['use'] && empty( $sct_options[ $tool ]['room_id'] ) ) ) {
 							$this->logger( 1002, 'chatwork', '1' );
-						};
+						}
 					}
 				}
 			}

--- a/class/class-sct-discord.php
+++ b/class/class-sct-discord.php
@@ -117,7 +117,7 @@ class Sct_Discord extends Sct_Generate_Content_Abstract {
 					break;
 				}
 				$content .= $value . "\n";
-				$i++;
+				++$i;
 			}
 
 			$header_emoji    = ':tada:';

--- a/class/class-sct-error-mail.php
+++ b/class/class-sct-error-mail.php
@@ -132,7 +132,7 @@ class Sct_Error_Mail extends Sct_Generate_Content_Abstract {
 				break;
 			}
 			$content .= $value . "\n";
-			$i++;
+			++$i;
 		}
 
 		$website_url     = $this->original_data['url']['website'];

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -344,7 +344,7 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 		};
 
 		if ( 200 !== $status_code && 204 !== $status_code ) {
-			require_once dirname( __FILE__ ) . '/class-sct-error-mail.php';
+			require_once __DIR__ . '/class-sct-error-mail.php';
 			$this->call_error_mail_class( $status_code, $tool_name );
 		}
 

--- a/class/class-sct-generate-content-abstract.php
+++ b/class/class-sct-generate-content-abstract.php
@@ -180,7 +180,7 @@ abstract class Sct_Generate_Content_Abstract extends Sct_Base {
 		foreach ( $update_content as $value ) {
 			$is_core                              = 'core' === $value['attribute'] ? null : 's';
 			${ "add_$value[attribute]$is_core" } .= "   $value[name] ( $value[current_version] -> $value[new_version] )\n";
-		};
+		}
 
 		$update_raw_data            = new stdClass();
 		$update_raw_data->core      = isset( $add_core ) ? esc_html__( 'WordPress Core:', 'send-chat-tools' ) . "\n" . $add_core . "\n" : null;

--- a/class/class-sct-logger.php
+++ b/class/class-sct-logger.php
@@ -33,13 +33,6 @@ class Sct_Logger extends Sct_Base {
 	public $result;
 
 	/**
-	 * Constructor.
-	 */
-	private function __construct() {
-		return $this;
-	}
-
-	/**
 	 * Instantiate and return itself.
 	 */
 	public static function get_instance(): Sct_Logger {

--- a/class/class-sct-slack.php
+++ b/class/class-sct-slack.php
@@ -158,7 +158,7 @@ class Sct_Slack extends Sct_Generate_Content_Abstract {
 					break;
 				}
 				$content .= $value . "\n";
-				$i++;
+				++$i;
 			}
 
 			$header_emoji    = ':tada:';

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "phpcompatibility/php-compatibility": "^9.3",
         "phpunit/phpunit": "^9.5",
         "szepeviktor/phpstan-wordpress": "^1.1",
-        "phpstan/phpstan": "^1.8"
+        "phpstan/phpstan": "^1.8",
+        "slevomat/coding-standard": "^8.13"
     },
     "scripts": {
         "post-autoload-dump": [

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.7",
-        "wp-coding-standards/wpcs": "^2.3",
+        "wp-coding-standards/wpcs": "^3.0.0",
         "wp-cli/wp-cli": "^2.6",
         "wp-cli/wp-cli-bundle": "^2.6",
         "phpcompatibility/php-compatibility": "^9.3",
@@ -34,5 +34,10 @@
         "make-jspot": "./vendor/bin/wp i18n make-pot . languages/js/send-chat-tools-ja.pot --skip-php",
         "make-pot": "./vendor/bin/wp i18n make-pot . languages/send-chat-tools-ja.po --skip-js",
         "make-json": "./vendor/bin/wp i18n make-json languages/js --no-purge"
+    },
+    "config": {
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "06b5199bb0b40ef3f089aafc9d80786d",
+    "content-hash": "aa49b203c93ea2c27adef1ce9c138699",
     "packages": [],
     "packages-dev": [
         {
@@ -1592,6 +1592,53 @@
                 "source": "https://github.com/PHPCSStandards/PHPCSUtils"
             },
             "time": "2023-07-16T21:39:41+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "3510b0a6274cc42f7219367cb3abfc123ffa09d6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/3510b0a6274cc42f7219367cb3abfc123ffa09d6",
+                "reference": "3510b0a6274cc42f7219367cb3abfc123ffa09d6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^4.15",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.24.0"
+            },
+            "time": "2023-09-07T20:46:32+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -3386,6 +3433,71 @@
                 "source": "https://github.com/Seldaek/phar-utils/tree/1.2.1"
             },
             "time": "2022-08-31T10:31:18+00:00"
+        },
+        {
+            "name": "slevomat/coding-standard",
+            "version": "8.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "4b2af2fb17773656d02fbfb5d18024ebd19fe322"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/4b2af2fb17773656d02fbfb5d18024ebd19fe322",
+                "reference": "4b2af2fb17773656d02fbfb5d18024ebd19fe322",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7 || ^1.0",
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpdoc-parser": "^1.23.0",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.4",
+                "php-parallel-lint/php-parallel-lint": "1.3.2",
+                "phpstan/phpstan": "1.10.26",
+                "phpstan/phpstan-deprecation-rules": "1.1.3",
+                "phpstan/phpstan-phpunit": "1.3.13",
+                "phpstan/phpstan-strict-rules": "1.5.1",
+                "phpunit/phpunit": "7.5.20|8.5.21|9.6.8|10.2.6"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "keywords": [
+                "dev",
+                "phpcs"
+            ],
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/8.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-07-25T10:28:55+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a2c214d8cd59a47247381f4ebfba5011",
+    "content-hash": "06b5199bb0b40ef3f089aafc9d80786d",
     "packages": [],
     "packages-dev": [
         {
@@ -548,6 +548,84 @@
                 }
             ],
             "time": "2022-02-25T21:32:43+00:00"
+        },
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/composer-installer.git",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/4be43904336affa5c2f70744a348312336afd0da",
+                "reference": "4be43904336affa5c2f70744a348312336afd0da",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPCSStandards\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/composer-installer/issues",
+                "source": "https://github.com/PHPCSStandards/composer-installer"
+            },
+            "time": "2023-01-05T11:28:13+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -1378,6 +1456,142 @@
                 "source": "https://github.com/PHPCompatibility/PHPCompatibility"
             },
             "time": "2019-12-27T09:44:58+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "98bcdbacbda14b1db85f710b1853125726795bbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/98bcdbacbda14b1db85f710b1853125726795bbc",
+                "reference": "98bcdbacbda14b1db85f710b1853125726795bbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "squizlabs/php_codesniffer": "^3.7.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "time": "2023-08-26T04:46:45+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.0.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/69465cab9d12454e5e7767b9041af0cd8cd13be7",
+                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.7.1 || 4.0.x-dev@dev"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "time": "2023-07-16T21:39:41+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -6463,30 +6677,38 @@
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "2.3.0",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62"
+                "reference": "bb792cb331472b82c5d7f28fb9b8ec2d20f68826"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/7da1894633f168fe244afc6de00d141f27517b62",
-                "reference": "7da1894633f168fe244afc6de00d141f27517b62",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/bb792cb331472b82c5d7f28fb9b8ec2d20f68826",
+                "reference": "bb792cb331472b82c5d7f28fb9b8ec2d20f68826",
                 "shasum": ""
             },
             "require": {
+                "ext-filter": "*",
+                "ext-libxml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlreader": "*",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.3.1"
+                "phpcsstandards/phpcsextra": "^1.1.0",
+                "phpcsstandards/phpcsutils": "^1.0.8",
+                "squizlabs/php_codesniffer": "^3.7.2"
             },
             "require-dev": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.5 || ^0.6",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
                 "phpcompatibility/php-compatibility": "^9.0",
-                "phpcsstandards/phpcsdevtools": "^1.0",
+                "phpcsstandards/phpcsdevtools": "^1.2.0",
                 "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "suggest": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.6 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically."
+                "ext-iconv": "For improved results",
+                "ext-mbstring": "For improved results"
             },
             "type": "phpcodesniffer-standard",
             "notification-url": "https://packagist.org/downloads/",
@@ -6503,6 +6725,7 @@
             "keywords": [
                 "phpcs",
                 "standards",
+                "static analysis",
                 "wordpress"
             ],
             "support": {
@@ -6510,7 +6733,7 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2020-05-13T23:57:56+00:00"
+            "time": "2023-08-21T14:28:38+00:00"
         }
     ],
     "aliases": [],
@@ -6520,5 +6743,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -5,6 +5,14 @@
         <exclude name="Universal.Operators.TypeSeparatorSpacing" />
     </rule>
     <rule ref="Universal.Operators.StrictComparisons" />
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+        <properties>
+            <property name="newlinesCountBetweenOpenTagAndDeclare" value="0" />
+            <property name="linesCountBeforeDeclare" value="1" />
+            <property name="linesCountAfterDeclare" value="1" />
+            <property name="spacesCountAroundEqualsSign" value="1" />
+        </properties>
+    </rule>
 
     <!-- Start: Exclude tests directory -->
     <!-- Class name rule -->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -26,4 +26,5 @@
     <!-- Exclude Directory, File. -->
     <exclude-pattern>/vendor</exclude-pattern>
     <exclude-pattern>/node_modules</exclude-pattern>
+    <exclude-pattern>/build</exclude-pattern>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <ruleset name="Custom WordPress">
     <rule ref="WordPress">
-        <exclude name="Generic.Arrays.DisallowShortArraySyntax" />
+        <exclude name="Universal.Arrays.DisallowShortArraySyntax" />
     </rule>
 
     <!-- Start: Exclude tests directory -->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,6 +4,7 @@
         <exclude name="Universal.Arrays.DisallowShortArraySyntax" />
         <exclude name="Universal.Operators.TypeSeparatorSpacing" />
     </rule>
+    <rule ref="Universal.Operators.StrictComparisons" />
 
     <!-- Start: Exclude tests directory -->
     <!-- Class name rule -->

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -2,6 +2,7 @@
 <ruleset name="Custom WordPress">
     <rule ref="WordPress">
         <exclude name="Universal.Arrays.DisallowShortArraySyntax" />
+        <exclude name="Universal.Operators.TypeSeparatorSpacing" />
     </rule>
 
     <!-- Start: Exclude tests directory -->

--- a/send-chat-tools.php
+++ b/send-chat-tools.php
@@ -22,9 +22,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit( 'You do not have access rights.' );
 }
 
-load_plugin_textdomain( 'send-chat-tools', false, basename( dirname( __FILE__ ) ) . '/languages' );
+load_plugin_textdomain( 'send-chat-tools', false, basename( __DIR__ ) . '/languages' );
 
-require_once dirname( __FILE__ ) . '/class/class-sct-phpver-judge.php';
+require_once __DIR__ . '/class/class-sct-phpver-judge.php';
 
 $sct_phpver_judge        = new Sct_Phpver_Judge();
 $sct_require_php_version = '8.0.0';
@@ -36,21 +36,21 @@ if ( ! $sct_phpver_judge->judgment( $sct_require_php_version ) ) {
 		$sct_require_php_version,
 	);
 } else {
-	require_once dirname( __FILE__ ) . '/class/class-sct-base.php';
-	require_once dirname( __FILE__ ) . '/class/class-sct-encryption.php';
-	require_once dirname( __FILE__ ) . '/class/class-sct-admin-page.php';
-	require_once dirname( __FILE__ ) . '/class/class-sct-check-comment.php';
-	require_once dirname( __FILE__ ) . '/class/class-sct-check-login.php';
-	require_once dirname( __FILE__ ) . '/class/class-sct-check-rinker.php';
-	require_once dirname( __FILE__ ) . '/class/class-sct-check-update.php';
-	require_once dirname( __FILE__ ) . '/class/class-sct-logger.php';
-	require_once dirname( __FILE__ ) . '/class/class-sct-activate.php';
-	require_once dirname( __FILE__ ) . '/class/class-sct-dashboard-notify.php';
-	require_once dirname( __FILE__ ) . '/class/class-sct-developer-notify.php';
-	require_once dirname( __FILE__ ) . '/class/class-sct-generate-content-abstract.php';
-	require_once dirname( __FILE__ ) . '/class/class-sct-slack.php';
-	require_once dirname( __FILE__ ) . '/class/class-sct-discord.php';
-	require_once dirname( __FILE__ ) . '/class/class-sct-chatwork.php';
+	require_once __DIR__ . '/class/class-sct-base.php';
+	require_once __DIR__ . '/class/class-sct-encryption.php';
+	require_once __DIR__ . '/class/class-sct-admin-page.php';
+	require_once __DIR__ . '/class/class-sct-check-comment.php';
+	require_once __DIR__ . '/class/class-sct-check-login.php';
+	require_once __DIR__ . '/class/class-sct-check-rinker.php';
+	require_once __DIR__ . '/class/class-sct-check-update.php';
+	require_once __DIR__ . '/class/class-sct-logger.php';
+	require_once __DIR__ . '/class/class-sct-activate.php';
+	require_once __DIR__ . '/class/class-sct-dashboard-notify.php';
+	require_once __DIR__ . '/class/class-sct-developer-notify.php';
+	require_once __DIR__ . '/class/class-sct-generate-content-abstract.php';
+	require_once __DIR__ . '/class/class-sct-slack.php';
+	require_once __DIR__ . '/class/class-sct-discord.php';
+	require_once __DIR__ . '/class/class-sct-chatwork.php';
 
 	/**
 	 * Start comment process.

--- a/tests/SctActivateTest.php
+++ b/tests/SctActivateTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare( strict_types = 1 );
 
 /**

--- a/tests/SctActivateTest.php
+++ b/tests/SctActivateTest.php
@@ -32,7 +32,7 @@ class SctActivateTest extends PHPUnit\Framework\TestCase {
 	 * SetUp.
 	 * Create instance.
 	 */
-	protected function setUp() :void {
+	protected function setUp(): void {
 		$this->instance = new Sct_Activate();
 	}
 

--- a/tests/SctAdminPageTest.php
+++ b/tests/SctAdminPageTest.php
@@ -28,7 +28,7 @@ class SctAdminPageTest extends PHPUnit\Framework\TestCase {
 	 * SetUp.
 	 * Create instance.
 	 */
-	protected function setUp() :void {
+	protected function setUp(): void {
 		$this->instance = new Sct_Admin_Page();
 	}
 

--- a/tests/SctAdminPageTest.php
+++ b/tests/SctAdminPageTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare( strict_types = 1 );
 
 /**

--- a/tests/SctBaseTest.php
+++ b/tests/SctBaseTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare( strict_types = 1 );
 
 /**

--- a/tests/SctBaseTest.php
+++ b/tests/SctBaseTest.php
@@ -28,7 +28,7 @@ class SctBaseTest extends PHPUnit\Framework\TestCase {
 	 * SetUp.
 	 * Create instance.
 	 */
-	protected function setUp() :void {
+	protected function setUp(): void {
 		$this->instance = new Sct_Base();
 	}
 

--- a/tests/SctCheckUpdateTest.php
+++ b/tests/SctCheckUpdateTest.php
@@ -28,7 +28,7 @@ class SctCheckUpdateTest extends PHPUnit\Framework\TestCase {
 	 * SetUp.
 	 * Create instance.
 	 */
-	protected function setUp() :void {
+	protected function setUp(): void {
 		$this->instance = new Sct_Check_Update();
 	}
 

--- a/tests/SctCheckUpdateTest.php
+++ b/tests/SctCheckUpdateTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare( strict_types = 1 );
 
 /**

--- a/tests/SctDashboardNotifyTest.php
+++ b/tests/SctDashboardNotifyTest.php
@@ -28,7 +28,7 @@ class SctDashboardNotifyTest extends PHPUnit\Framework\TestCase {
 	 * SetUp.
 	 * Create instance.
 	 */
-	protected function setUp() :void {
+	protected function setUp(): void {
 		$this->instance = new Sct_Dashboard_Notify();
 	}
 

--- a/tests/SctDashboardNotifyTest.php
+++ b/tests/SctDashboardNotifyTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare( strict_types = 1 );
 
 /**

--- a/tests/SctDeveloperNotifyTest.php
+++ b/tests/SctDeveloperNotifyTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare( strict_types = 1 );
 
 /**

--- a/tests/SctDeveloperNotifyTest.php
+++ b/tests/SctDeveloperNotifyTest.php
@@ -32,7 +32,7 @@ class SctDeveloperNotifyTest extends PHPUnit\Framework\TestCase {
 	 * SetUp.
 	 * Create instance.
 	 */
-	protected function setUp() :void {
+	protected function setUp(): void {
 		$this->instance = new Sct_Developer_Notify();
 	}
 

--- a/tests/SctEncryptionTest.php
+++ b/tests/SctEncryptionTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare( strict_types = 1 );
 
 /**

--- a/tests/SctEncryptionTest.php
+++ b/tests/SctEncryptionTest.php
@@ -28,7 +28,7 @@ class SctEncryptionTest extends PHPUnit\Framework\TestCase {
 	 * SetUp.
 	 * Create instance.
 	 */
-	protected function setUp() :void {
+	protected function setUp(): void {
 		$this->instance = new Sct_Encryption();
 	}
 

--- a/tests/SctErrorMailTest.php
+++ b/tests/SctErrorMailTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare( strict_types = 1 );
 
 /**

--- a/tests/SctErrorMailTest.php
+++ b/tests/SctErrorMailTest.php
@@ -29,7 +29,7 @@ class SctErrorMailTest extends PHPUnit\Framework\TestCase {
 	 * SetUp.
 	 * Create instance.
 	 */
-	protected function setUp() :void {
+	protected function setUp(): void {
 	}
 
 	/**

--- a/tests/SctLoggerTest.php
+++ b/tests/SctLoggerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare( strict_types = 1 );
 
 /**

--- a/tests/SctLoggerTest.php
+++ b/tests/SctLoggerTest.php
@@ -28,7 +28,7 @@ class SctLoggerTest extends PHPUnit\Framework\TestCase {
 	 * SetUp.
 	 * Create instance.
 	 */
-	protected function setUp() :void {
+	protected function setUp(): void {
 		$this->instance = Sct_Logger::get_instance();
 	}
 

--- a/tests/SctPhpverJudgeTest.php
+++ b/tests/SctPhpverJudgeTest.php
@@ -28,7 +28,7 @@ class SctPhpverJudgeTest extends PHPUnit\Framework\TestCase {
 	 * SetUp.
 	 * Create instance.
 	 */
-	protected function setUp() :void {
+	protected function setUp(): void {
 		$this->instance = new Sct_Phpver_Judge();
 	}
 

--- a/tests/SctPhpverJudgeTest.php
+++ b/tests/SctPhpverJudgeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 declare( strict_types = 1 );
 
 /**

--- a/tests/lib/wordpress-functions.php
+++ b/tests/lib/wordpress-functions.php
@@ -50,14 +50,6 @@ function get_comment( $comment ) {
 	return $comment_data;
 }
 
-function get_permalink( $id ) {
-	return 'https://www.example.com/my-post';
-}
-
-function get_the_title( $id ) {
-	return 'Test article';
-}
-
 function do_action() {
 	return true;
 }

--- a/tests/lib/wordpress-functions.php
+++ b/tests/lib/wordpress-functions.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types = 1);
+
 function get_option( $str ) {
 	$value = [];
 


### PR DESCRIPTION
- refs #601 update package -> wp-coding-standards/wpcs
- refs #601 fix short array syntax rule name with wpcs update
- refs #601 add exclude path -> build directory
- refs #601 fix colon space
- refs #601 fix colon space
- refs #601 add exclude sniff rules -> TypeSeparatorSpacing
- refs #601 add sniff -> StrictComparisons
- refs #601 add sniff -> DeclareStrictTypes
- refs #601 add package -> slevomat/coding-standard
- refs #601 fix remove unnecessary semicolon
- refs #601 fix increment order
- refs #601 fix increment order
- refs #601 fix remove unnecessary semicolon
- refs #601 fix remove unnecessary semicolon
- refs #601 fix increment order
- refs #601 fix add declare before blank line
- refs #601 fix use cpabilities
- refs #601 remove constructor
- refs #601 fix use __DIR__
- refs #601 fix remove unnecessary semicolon
- refs #601 remove unnecessary semicolon
- refs #601 use cpabilities
- refs #601 remove unnecessary semicolon
- refs #601 fix use elseif block
- refs #601 fix use elseif block
- refs #601 fix use __DIR__
- refs #601 ignore phpcs
- refs #601 ignore phpcs
- refs #601 add declare
- refs #601 remove unused functions
