### PR TITLE
606 fix MenuItem component icon use element

### DIFF
--- a/src/components/atoms/LogExportButton.tsx
+++ b/src/components/atoms/LogExportButton.tsx
@@ -1,4 +1,4 @@
-import { Button, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
+import { Button, Dashicon, Dropdown, MenuGroup, MenuItem } from '@wordpress/components';
 
 import { useLogExport } from 'src/hooks/useLogExport';
 
@@ -24,7 +24,7 @@ export const LogExportButton = () => {
 					{ items.map( ( item: itemType, index ) => (
 						<MenuItem
 							key={ index }
-							icon={ item.icon }
+							icon={ <Dashicon icon={ item.icon } /> }
 							onClick={ () => copyLogs( item.key ) }
 						>
 							{ item.text }


### PR DESCRIPTION
- refs #603 update package -> phpstan
- refs #603 remove package -> wp-cli, wp-cli-bundle
- refs #603 update package -> phpunit
- refs #603 package update -> @types/react
- refs #603 update package -> @types/wordpress__components
- refs #603 update package -> typescript
- refs #603 update package -> ts-loader
- refs #603 update package -> thread-loader
- refs #603 update package -> eslint-import-resolver-typescript
- refs #603 update package -> esbuild-loader
- refs #603 update package -> @wordpress/scripts
- refs #603 update package -> @wordpress/i18n
- refs #603 update package -> @wordpress/env
- refs #603 update package -> @wordpress/api-fetch
- refs #603 update package -> @wordpress/components
- refs #603 update package -> @wordpress/components
- refs #606 fix use Dashicon component
