### PR TITLE
629 fix phpunit tests

### DIFF
--- a/bin/after-start-scripts.sh
+++ b/bin/after-start-scripts.sh
@@ -1,4 +1,5 @@
 npm run wp-env run cli -- wp plugin delete akismet hello
+npm run wp-env run cli -- wp theme install twentytwentyfour
 
 network_hash=$(basename "$(npm run wp-env install-path)")
 mailpit_host="mailpit-${network_hash:0:8}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@wordpress/components": "^25.16.0"
       },
       "devDependencies": {
-        "@wordpress/env": "^9.2.0",
+        "@wordpress/env": "^9.3.0",
         "@wordpress/scripts": "^27.1.0",
         "esbuild-loader": "^4.0.3",
         "eslint-import-resolver-typescript": "^3.6.1",
@@ -5636,9 +5636,9 @@
       }
     },
     "node_modules/@wordpress/env": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-9.2.0.tgz",
-      "integrity": "sha512-2gl65WYbkuTjnW2SHKjeqdpLTgnPc/xVvFiwG+2p/RJwDHSuw1xXSdFqFUh3+wC/4cuXy9b2ZBm/SYsBoc8DDw==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-9.3.0.tgz",
+      "integrity": "sha512-qFu/my4SnlM43SItbmTCEVZrXC1p9Qyk/JQ7/6/0GYS/2vuKTjYgb/wfn3HJpUzay3DrbATlqAv9WfJHlyaEZw==",
       "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -26924,9 +26924,9 @@
       }
     },
     "@wordpress/env": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-9.2.0.tgz",
-      "integrity": "sha512-2gl65WYbkuTjnW2SHKjeqdpLTgnPc/xVvFiwG+2p/RJwDHSuw1xXSdFqFUh3+wC/4cuXy9b2ZBm/SYsBoc8DDw==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/env/-/env-9.3.0.tgz",
+      "integrity": "sha512-qFu/my4SnlM43SItbmTCEVZrXC1p9Qyk/JQ7/6/0GYS/2vuKTjYgb/wfn3HJpUzay3DrbATlqAv9WfJHlyaEZw==",
       "dev": true,
       "requires": {
         "chalk": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@wordpress/components": "^25.16.0"
   },
   "devDependencies": {
-    "@wordpress/env": "^9.2.0",
+    "@wordpress/env": "^9.3.0",
     "@wordpress/scripts": "^27.1.0",
     "esbuild-loader": "^4.0.3",
     "eslint-import-resolver-typescript": "^3.6.1",

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -23,3 +23,5 @@ function _manually_load_plugin() {
 tests_add_filter( 'plugins_loaded', '_manually_load_plugin' );
 
 WPIntegration\bootstrap_it();
+
+define( 'ROOT_DIR', dirname( __DIR__ ) );

--- a/tests/class-sct-activate-test.php
+++ b/tests/class-sct-activate-test.php
@@ -2,10 +2,12 @@
 
 declare( strict_types = 1 );
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Test: Sct_Activate
  */
-class SctActivateTest extends PHPUnit\Framework\TestCase {
+class Sct_Activate_Test extends TestCase {
 	/**
 	 * This test class instance.
 	 *
@@ -17,23 +19,19 @@ class SctActivateTest extends PHPUnit\Framework\TestCase {
 	 * Settings: ABSPATH, test class file, WordPress functions.
 	 */
 	public static function setUpBeforeClass(): void {
-		if ( ! defined( 'ABSPATH' ) ) {
-			define( 'ABSPATH', '' );
-		}
-
 		if ( ! class_exists( 'Sct_Base ' ) ) {
 			require_once './class/class-sct-base.php';
 		}
 
 		require_once './class/class-sct-activate.php';
-		require_once './tests/lib/wordpress-functions.php';
 	}
 
 	/**
 	 * SetUp.
 	 * Create instance.
 	 */
-	protected function setUp(): void {
+	public function set_up(): void {
+		parent::set_up();
 		$this->instance = new Sct_Activate();
 	}
 

--- a/tests/class-sct-admin-page-test.php
+++ b/tests/class-sct-admin-page-test.php
@@ -2,10 +2,12 @@
 
 declare( strict_types = 1 );
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Test: Sct_Admin_Page
  */
-class SctAdminPageTest extends PHPUnit\Framework\TestCase {
+class Sct_Admin_Page_Test extends TestCase {
 	/**
 	 * This test class instance.
 	 *
@@ -17,19 +19,19 @@ class SctAdminPageTest extends PHPUnit\Framework\TestCase {
 	 * Settings: ABSPATH, test class file, WordPress functions.
 	 */
 	public static function setUpBeforeClass(): void {
-		if ( ! defined( 'ABSPATH' ) ) {
-			define( 'ABSPATH', '' );
+		if ( ! class_exists( 'Sct_Base ' ) ) {
+			require_once './class/class-sct-base.php';
 		}
 
 		require_once './class/class-sct-admin-page.php';
-		require_once './tests/lib/wordpress-functions.php';
 	}
 
 	/**
 	 * SetUp.
 	 * Create instance.
 	 */
-	protected function setUp(): void {
+	public function set_up(): void {
+		parent::set_up();
 		$this->instance = new Sct_Admin_Page();
 	}
 

--- a/tests/class-sct-base-test.php
+++ b/tests/class-sct-base-test.php
@@ -57,7 +57,7 @@ class Sct_Base_Test extends TestCase {
 		$method->setAccessible( true );
 
 		$this->assertSame(
-			'https://example.com/wp-content/plugins/send-chat-tools',
+			home_url( '/wp-content/plugins/send-chat-tools' ),
 			$method->invoke( $this->instance, 'send-chat-tools' ),
 		);
 	}

--- a/tests/class-sct-base-test.php
+++ b/tests/class-sct-base-test.php
@@ -2,10 +2,12 @@
 
 declare( strict_types = 1 );
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Test: Sct_Base
  */
-class SctBaseTest extends PHPUnit\Framework\TestCase {
+class Sct_Base_Test extends TestCase {
 	/**
 	 * This test class instance.
 	 *
@@ -17,19 +19,19 @@ class SctBaseTest extends PHPUnit\Framework\TestCase {
 	 * Settings: ABSPATH, test class file, WordPress functions.
 	 */
 	public static function setUpBeforeClass(): void {
-		if ( ! defined( 'ABSPATH' ) ) {
-			define( 'ABSPATH', '' );
+		if ( ! class_exists( 'Sct_Base ' ) ) {
+			require_once './class/class-sct-base.php';
 		}
 
 		require_once './class/class-sct-base.php';
-		require_once './tests/lib/wordpress-functions.php';
 	}
 
 	/**
 	 * SetUp.
 	 * Create instance.
 	 */
-	protected function setUp(): void {
+	public function set_up(): void {
+		parent::set_up();
 		$this->instance = new Sct_Base();
 	}
 

--- a/tests/class-sct-base-test.php
+++ b/tests/class-sct-base-test.php
@@ -70,7 +70,7 @@ class Sct_Base_Test extends TestCase {
 		$method->setAccessible( true );
 
 		$this->assertSame(
-			'/DocumentRoot/wp-content/plugins/send-chat-tools',
+			get_home_path() . 'wp-content/plugins/send-chat-tools',
 			$method->invoke( $this->instance, 'send-chat-tools' ),
 		);
 	}

--- a/tests/class-sct-base-test.php
+++ b/tests/class-sct-base-test.php
@@ -83,7 +83,7 @@ class Sct_Base_Test extends TestCase {
 		$method->setAccessible( true );
 
 		$this->assertSame(
-			'/DocumentRoot/wp-content/plugins/send-chat-tools/send-chat-tools.php',
+			plugin_dir_path( ROOT_DIR ) . 'send-chat-tools/send-chat-tools.php',
 			$method->invoke( $this->instance )
 		);
 	}

--- a/tests/class-sct-check-update-test.php
+++ b/tests/class-sct-check-update-test.php
@@ -2,10 +2,12 @@
 
 declare( strict_types = 1 );
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Test: Sct_Admin_Page
  */
-class SctCheckUpdateTest extends PHPUnit\Framework\TestCase {
+class Sct_Check_Update_Test extends TestCase {
 	/**
 	 * This test class instance.
 	 *
@@ -17,19 +19,19 @@ class SctCheckUpdateTest extends PHPUnit\Framework\TestCase {
 	 * Settings: ABSPATH, test class file, WordPress functions.
 	 */
 	public static function setUpBeforeClass(): void {
-		if ( ! defined( 'ABSPATH' ) ) {
-			define( 'ABSPATH', '' );
+		if ( ! class_exists( 'Sct_Base ' ) ) {
+			require_once './class/class-sct-base.php';
 		}
 
 		require_once './class/class-sct-check-update.php';
-		require_once './tests/lib/wordpress-functions.php';
 	}
 
 	/**
 	 * SetUp.
 	 * Create instance.
 	 */
-	protected function setUp(): void {
+	public function set_up(): void {
+		parent::set_up();
 		$this->instance = new Sct_Check_Update();
 	}
 

--- a/tests/class-sct-dashboard-notify-test.php
+++ b/tests/class-sct-dashboard-notify-test.php
@@ -2,10 +2,12 @@
 
 declare( strict_types = 1 );
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Test: Sct_Dashboard_Notify
  */
-class SctDashboardNotifyTest extends PHPUnit\Framework\TestCase {
+class Sct_Dashboard_Notify_Test extends TestCase {
 	/**
 	 * This test class instance.
 	 *
@@ -17,19 +19,19 @@ class SctDashboardNotifyTest extends PHPUnit\Framework\TestCase {
 	 * Settings: ABSPATH, test class file, WordPress functions.
 	 */
 	public static function setUpBeforeClass(): void {
-		if ( ! defined( 'ABSPATH' ) ) {
-			define( 'ABSPATH', '' );
+		if ( ! class_exists( 'Sct_Base ' ) ) {
+			require_once './class/class-sct-base.php';
 		}
 
 		require_once './class/class-sct-dashboard-notify.php';
-		require_once './tests/lib/wordpress-functions.php';
 	}
 
 	/**
 	 * SetUp.
 	 * Create instance.
 	 */
-	protected function setUp(): void {
+	public function set_up(): void {
+		parent::set_up();
 		$this->instance = new Sct_Dashboard_Notify();
 	}
 

--- a/tests/class-sct-developer-notify-test.php
+++ b/tests/class-sct-developer-notify-test.php
@@ -2,10 +2,12 @@
 
 declare( strict_types = 1 );
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Test: Sct_Developer_Notify
  */
-class SctDeveloperNotifyTest extends PHPUnit\Framework\TestCase {
+class Sct_Developer_Notify_Test extends TestCase {
 	/**
 	 * This test class instance.
 	 *
@@ -17,23 +19,19 @@ class SctDeveloperNotifyTest extends PHPUnit\Framework\TestCase {
 	 * Settings: ABSPATH, test class file, WordPress functions.
 	 */
 	public static function setUpBeforeClass(): void {
-		if ( ! defined( 'ABSPATH' ) ) {
-			define( 'ABSPATH', '' );
-		}
-
 		if ( ! class_exists( 'Sct_Base ' ) ) {
 			require_once './class/class-sct-base.php';
 		}
 
 		require_once './class/class-sct-developer-notify.php';
-		require_once './tests/lib/wordpress-functions.php';
 	}
 
 	/**
 	 * SetUp.
 	 * Create instance.
 	 */
-	protected function setUp(): void {
+	public function set_up(): void {
+		parent::set_up();
 		$this->instance = new Sct_Developer_Notify();
 	}
 

--- a/tests/class-sct-developer-notify-test.php
+++ b/tests/class-sct-developer-notify-test.php
@@ -94,6 +94,10 @@ class Sct_Developer_Notify_Test extends TestCase {
 		$method = new ReflectionMethod( $this->instance, 'developer_message_key_exists' );
 		$method->setAccessible( true );
 
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+		activate_plugin( plugin_dir_path( ROOT_DIR ) . 'send-chat-tools/send-chat-tools.php' );
+
 		$this->assertSame(
 			$expected,
 			$method->invoke( $this->instance, $developer_message ),
@@ -219,21 +223,21 @@ class Sct_Developer_Notify_Test extends TestCase {
 		return [
 			'theme'     => [
 				[
-					'key'  => 'my-theme',
+					'key'  => 'twentytwentyfour',
 					'type' => 'theme',
 				],
 				true,
 			],
 			'plugin'    => [
 				[
-					'key'  => 'my-plugin/my-plugin.php',
+					'key'  => 'send-chat-tools/send-chat-tools.php',
 					'type' => 'plugin',
 				],
 				true,
 			],
 			'type less' => [
 				[
-					'key'  => 'my-theme',
+					'key'  => 'twentytwentyfour',
 					'type' => '',
 				],
 				false,

--- a/tests/class-sct-encryption-test.php
+++ b/tests/class-sct-encryption-test.php
@@ -2,10 +2,12 @@
 
 declare( strict_types = 1 );
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
- * Test: Sct_Logger
+ * Test: Sct_Encryption
  */
-class SctLoggerTest extends PHPUnit\Framework\TestCase {
+class Sct_Encryption_Test extends TestCase {
 	/**
 	 * This test class instance.
 	 *
@@ -17,33 +19,32 @@ class SctLoggerTest extends PHPUnit\Framework\TestCase {
 	 * Settings: ABSPATH, test class file, WordPress functions.
 	 */
 	public static function setUpBeforeClass(): void {
-		if ( ! defined( 'ABSPATH' ) ) {
-			define( 'ABSPATH', '' );
+		if ( ! class_exists( 'Sct_Base ' ) ) {
+			require_once './class/class-sct-base.php';
 		}
 
-		require_once './class/class-sct-logger.php';
-		require_once './tests/lib/wordpress-functions.php';
+		require_once './class/class-sct-encryption.php';
 	}
 
 	/**
 	 * SetUp.
 	 * Create instance.
 	 */
-	protected function setUp(): void {
-		$this->instance = Sct_Logger::get_instance();
+	public function set_up(): void {
+		parent::set_up();
+		$this->instance = new Sct_Encryption();
 	}
 
 	/**
-	 * TEST: create_log()
+	 * TEST: make_vector()
 	 */
-	public function test_create_log() {
+	public function test_make_vector() {
 		$this->markTestIncomplete( 'This test is incomplete.' );
 	}
-
 	/**
-	 * TEST: save_log()
+	 * TEST: decrypt()
 	 */
-	public function test_save_log() {
+	public function test_decrypt() {
 		$this->markTestIncomplete( 'This test is incomplete.' );
 	}
 }

--- a/tests/class-sct-error-mail-test.php
+++ b/tests/class-sct-error-mail-test.php
@@ -2,10 +2,12 @@
 
 declare( strict_types = 1 );
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Test: Sct_Error_Mail
  */
-class SctErrorMailTest extends PHPUnit\Framework\TestCase {
+class Sct_Error_Mail_Test extends TestCase {
 	/**
 	 * This test class instance.
 	 *
@@ -17,20 +19,21 @@ class SctErrorMailTest extends PHPUnit\Framework\TestCase {
 	 * Settings: ABSPATH, test class file, WordPress functions.
 	 */
 	public static function setUpBeforeClass(): void {
-		if ( ! defined( 'ABSPATH' ) ) {
-			define( 'ABSPATH', '' );
+		if ( ! class_exists( 'Sct_Base ' ) ) {
+			require_once './class/class-sct-base.php';
 		}
 
 		require_once './class/class-sct-generate-content-abstract.php';
 		require_once './class/class-sct-error-mail.php';
-		require_once './tests/lib/wordpress-functions.php';
 	}
 
 	/**
 	 * SetUp.
 	 * Create instance.
 	 */
-	protected function setUp(): void {
+	public function set_up(): void {
+		parent::set_up();
+		$this->instance = new Sct_Error_Mail();
 	}
 
 	/**

--- a/tests/class-sct-logger-test.php
+++ b/tests/class-sct-logger-test.php
@@ -2,10 +2,12 @@
 
 declare( strict_types = 1 );
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
- * Test: Sct_Encryption
+ * Test: Sct_Logger
  */
-class SctEncryptionTest extends PHPUnit\Framework\TestCase {
+class Sct_Logger_Test extends TestCase {
 	/**
 	 * This test class instance.
 	 *
@@ -17,32 +19,33 @@ class SctEncryptionTest extends PHPUnit\Framework\TestCase {
 	 * Settings: ABSPATH, test class file, WordPress functions.
 	 */
 	public static function setUpBeforeClass(): void {
-		if ( ! defined( 'ABSPATH' ) ) {
-			define( 'ABSPATH', '' );
+		if ( ! class_exists( 'Sct_Base ' ) ) {
+			require_once './class/class-sct-base.php';
 		}
 
-		require_once './class/class-sct-encryption.php';
-		require_once './tests/lib/wordpress-functions.php';
+		require_once './class/class-sct-logger.php';
 	}
 
 	/**
 	 * SetUp.
 	 * Create instance.
 	 */
-	protected function setUp(): void {
-		$this->instance = new Sct_Encryption();
+	public function set_up(): void {
+		parent::set_up();
+		$this->instance = Sct_Logger::get_instance();
 	}
 
 	/**
-	 * TEST: make_vector()
+	 * TEST: create_log()
 	 */
-	public function test_make_vector() {
+	public function test_create_log() {
 		$this->markTestIncomplete( 'This test is incomplete.' );
 	}
+
 	/**
-	 * TEST: decrypt()
+	 * TEST: save_log()
 	 */
-	public function test_decrypt() {
+	public function test_save_log() {
 		$this->markTestIncomplete( 'This test is incomplete.' );
 	}
 }

--- a/tests/class-sct-phpver-judge-test.php
+++ b/tests/class-sct-phpver-judge-test.php
@@ -2,10 +2,12 @@
 
 declare( strict_types = 1 );
 
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
 /**
  * Test: Sct_Phpver_Judge
  */
-class SctPhpverJudgeTest extends PHPUnit\Framework\TestCase {
+class Sct_Phpver_Judge_Test extends TestCase {
 	/**
 	 * This test class instance.
 	 *
@@ -17,19 +19,19 @@ class SctPhpverJudgeTest extends PHPUnit\Framework\TestCase {
 	 * Settings: ABSPATH, test class file, WordPress functions.
 	 */
 	public static function setUpBeforeClass(): void {
-		if ( ! defined( 'ABSPATH' ) ) {
-			define( 'ABSPATH', '' );
+		if ( ! class_exists( 'Sct_Base ' ) ) {
+			require_once './class/class-sct-base.php';
 		}
 
 		require_once './class/class-sct-phpver-judge.php';
-		require_once './tests/lib/wordpress-functions.php';
 	}
 
 	/**
 	 * SetUp.
 	 * Create instance.
 	 */
-	protected function setUp(): void {
+	public function set_up(): void {
+		parent::set_up();
 		$this->instance = new Sct_Phpver_Judge();
 	}
 

--- a/tests/class-sct-phpver-judge-test.php
+++ b/tests/class-sct-phpver-judge-test.php
@@ -33,6 +33,7 @@ class Sct_Phpver_Judge_Test extends TestCase {
 	public function set_up(): void {
 		parent::set_up();
 		$this->instance = new Sct_Phpver_Judge();
+		switch_to_locale( 'en_US' );
 	}
 
 	/**


### PR DESCRIPTION
- refs #629 fix use wp-env PHPUnit
- refs #629 fix use wp-env PHPUnit
- refs #629 add locale change
- refs #629 fix use home_url function
- refs #629 fix use get_home_path function
- refs #629 add define -> ROOT_DIR
- refs #629 fix use plugin_dir path function
- refs #629 add Send Chat Tools avtivate, switch theme and date provider use twentytwentyfour
- refs #629 add theme install -> twentytwentyfour
- refs #629 package update -> @wordpress/env
